### PR TITLE
feat(k8s): headless lifecycle CLI, extra ports, registries.yaml, merged dory kubeconfig context

### DIFF
--- a/Dory/Models/AppStore.swift
+++ b/Dory/Models/AppStore.swift
@@ -176,7 +176,12 @@ final class AppStore {
     var selectedIngress: KubeIngressRow?
 
     private var namespaceFilter: String? { kubeNamespace == "All Namespaces" ? nil : kubeNamespace }
-    var kubeconfigHint: String { KubeContextHint.snippet(kubeconfigPath: KubernetesProvisioner.kubeconfigPath) }
+    var kubeconfigHint: String {
+        KubeContextHint.snippet(
+            kubeconfigPath: KubernetesProvisioner.kubeconfigPath,
+            merged: KubernetesProvisioner.hostKubectl() != nil
+        )
+    }
     func selectedPod() -> Pod? { pods.first { $0.id == selectedPodID } }
     func selectedDeployment() -> KubeDeploymentRow? { deployments.first { $0.id == selectedDeploymentID } }
 
@@ -3403,6 +3408,8 @@ final class AppStore {
             ) { message in
                 Task { @MainActor in self.kubernetesInfo = message }
             }
+        } catch KubernetesProvisioner.K8sError.configDrift {
+            kubernetesInfo = "Kubernetes create-time config changed; disable and re-enable Kubernetes to apply"
         } catch {
             let message = "Kubernetes failed: \(error)"
             kubernetesInfo = message

--- a/Dory/Runtime/Kubernetes/KubeContextHint.swift
+++ b/Dory/Runtime/Kubernetes/KubeContextHint.swift
@@ -1,10 +1,15 @@
 import Foundation
 
 enum KubeContextHint {
-    static func snippet(kubeconfigPath: String) -> String {
-        """
+    /// `merged` mirrors the enable-time merge condition (host kubectl present): the context then
+    /// lives in ~/.kube/config and no KUBECONFIG export is needed. Without kubectl the side file
+    /// is the only access path, so the hint keeps the export line.
+    static func snippet(kubeconfigPath: String, merged: Bool) -> String {
+        let command = "kubectl --context \(KubernetesProvisioner.contextName) get pods -A"
+        guard !merged else { return command }
+        return """
         export KUBECONFIG=\(kubeconfigPath)
-        kubectl get pods -A
+        \(command)
         """
     }
 }

--- a/Dory/Runtime/Kubernetes/KubernetesProvider.swift
+++ b/Dory/Runtime/Kubernetes/KubernetesProvider.swift
@@ -59,8 +59,8 @@ struct KubernetesStatus: Sendable {
     }
 }
 
-/// Surfaces an existing Kubernetes cluster via `kubectl`. One-click bootstrap of k3s is provided
-/// separately (scripts/enable-kubernetes.sh) because it boots infrastructure.
+/// Surfaces an existing Kubernetes cluster via `kubectl`. Dory can bootstrap its built-in k3s
+/// cluster through KubernetesProvisioner or `dory k8s enable`.
 struct KubernetesProvider: Sendable {
     var kubectlPath: String? {
         HostTools.kubectl()

--- a/Dory/Runtime/Kubernetes/KubernetesProvisioner.swift
+++ b/Dory/Runtime/Kubernetes/KubernetesProvisioner.swift
@@ -7,11 +7,29 @@ import Foundation
 /// locally-built Docker image is therefore NOT automatically visible to Pods — push it to a registry
 /// the cluster can reach, or import it into k3s's containerd (`k8s.io` namespace). Auto image-sync is
 /// a tracked follow-up.
+///
+/// Two optional host-side config files extend the cluster without GUI plumbing (and are shared
+/// with the `dory k8s` CLI):
+///   • `~/.dory/k8s/ports` — extra port publishings, one `HOST:CONTAINER[/proto]` per line.
+///     Published ports are auto-forwarded to `localhost` like any container's, so k3s NodePorts
+///     become host-reachable (e.g. `30500:30500` for a local registry).
+///   • `~/.dory/k8s/registries.yaml` — bind-mounted read-only to `/etc/rancher/k3s/registries.yaml`,
+///     k3s' native registry mirror/trust config. Living on the host, it survives the cluster
+///     container being recreated (k3s reads it at boot).
 enum KubernetesProvisioner {
     static let containerName = "dory-k8s"
     nonisolated static let defaultImage = KubeVersionCatalog.latest.image
     static let apiPort = 6443
+    /// Name used for the cluster/user/context in the exported kubeconfig, replacing k3s' generic
+    /// `default` so tools can target the cluster with `--context dory`.
+    static let contextName = "dory"
     static var kubeconfigPath: String { "\(NSHomeDirectory())/.kube/dory-config" }
+    /// The standard kubeconfig the `dory` context is merged into (via kubectl) so
+    /// `kubectl --context dory` works with no KUBECONFIG setup, like docker-desktop/orbstack/colima.
+    static var defaultKubeconfigPath: String { "\(NSHomeDirectory())/.kube/config" }
+    static var configDirectory: String { "\(NSHomeDirectory())/.dory/k8s" }
+    static var extraPortsConfigPath: String { "\(configDirectory)/ports" }
+    static var registriesConfigPath: String { "\(configDirectory)/registries.yaml" }
 
     enum K8sError: Error, Sendable, CustomStringConvertible {
         case createFailed(String)
@@ -20,6 +38,10 @@ enum KubernetesProvisioner {
         case kubectlMissing
         case apiUnreachable(String)
         case containerExited(String)
+        case invalidPortConfig(path: String, line: Int, value: String)
+        /// The container exists but its create-time config (ports/binds) no longer matches the
+        /// requested config; only disable + enable can apply the change.
+        case configDrift
 
         var description: String {
             switch self {
@@ -35,17 +57,80 @@ enum KubernetesProvisioner {
                 return detail.isEmpty ? "the Kubernetes API is not reachable from macOS" : "the Kubernetes API is not reachable from macOS: \(detail)"
             case .containerExited(let detail):
                 return detail.isEmpty ? "the k3s container exited during startup" : "the k3s container exited during startup: \(detail)"
+            case .invalidPortConfig(let path, let line, let value):
+                return "invalid Kubernetes port config at \(path):\(line): \(value)"
+            case .configDrift:
+                return "Kubernetes create-time config changed; disable and re-enable Kubernetes to apply"
             }
         }
     }
 
+    /// An extra `HOST:CONTAINER[/tcp|udp]` publishing on the cluster container.
+    struct PortPublish: Equatable, Hashable, Sendable {
+        var host: Int
+        var container: Int
+        var proto: String
+
+        static func parse(_ line: String) -> PortPublish? {
+            let normalized = normalizedConfigText(line)
+            guard !normalized.isEmpty else { return nil }
+            let portsAndProto = normalized.split(separator: "/", maxSplits: 1, omittingEmptySubsequences: false)
+            let proto = portsAndProto.count == 2 ? String(portsAndProto[1]) : "tcp"
+            guard proto == "tcp" || proto == "udp" else { return nil }
+            let parts = portsAndProto[0].split(separator: ":", omittingEmptySubsequences: false)
+            guard parts.count == 2, let host = Int(parts[0]), let container = Int(parts[1]),
+                  (1...65535).contains(host), (1...65535).contains(container) else { return nil }
+            return PortPublish(host: host, container: container, proto: proto)
+        }
+
+        static func normalizedConfigText(_ line: String) -> String {
+            let withoutComment = line.split(separator: "#", maxSplits: 1, omittingEmptySubsequences: false).first.map(String.init) ?? ""
+            return withoutComment.components(separatedBy: .whitespacesAndNewlines).joined()
+        }
+    }
+
+    private enum ExistingContainerState {
+        case absent
+        case running
+        case stopped
+    }
+
+    private struct KubernetesCreateRequest: Encodable {
+        let Image: String
+        let Cmd: [String]
+        let ExposedPorts: [String: DockerEmptyObject]
+        let HostConfig: HostConfigBody
+
+        struct HostConfigBody: Encodable {
+            let Privileged: Bool
+            let PortBindings: [String: [DockerPortBinding]]
+            let Binds: [String]?
+        }
+    }
+
+    private static let registriesBindTarget = "/etc/rancher/k3s/registries.yaml"
+
     static func enable(runtime: any ContainerRuntime, image: String = defaultImage, progress: @Sendable (String) -> Void = { _ in }) async throws {
-        if await isRunning(runtime) {
-            try await writeKubeconfig(runtime)
-            progress("Waiting for Kubernetes API access…")
-            try await waitForHostAPI(runtime, progress: progress)
-            progress("Kubernetes is running")
-            return
+        let extraPorts = try loadExtraPorts()
+        switch await existingContainerState(runtime) {
+        case .running:
+            if await publishedPortsCurrent(runtime, extraPorts: extraPorts) {
+                try await writeKubeconfig(runtime)
+                progress("Waiting for Kubernetes API access…")
+                try await waitForHostAPI(runtime, progress: progress)
+                progress("Kubernetes is running")
+                return
+            }
+            throw K8sError.configDrift
+        case .stopped:
+            if await publishedPortsCurrent(runtime, extraPorts: extraPorts) {
+                try await runtime.start(containerID: containerName)
+                try await waitUntilReady(runtime: runtime, progress: progress)
+                return
+            }
+            throw K8sError.configDrift
+        case .absent:
+            break
         }
 
         progress("Pulling Kubernetes (k3s)…")
@@ -55,7 +140,8 @@ enum KubernetesProvisioner {
         await deleteExisting(runtime)
         let encodedName = DockerImageOps.queryValue(containerName)
         guard let create = await runtime.proxyRequest(method: "POST", path: "/containers/create?name=\(encodedName)",
-            headers: [(name: "Content-Type", value: "application/json")], body: createBody(image: image)) else {
+            headers: [(name: "Content-Type", value: "application/json")],
+            body: createBody(image: image, extraPorts: extraPorts, registriesBind: registriesBindSource())) else {
             throw K8sError.createFailed("")
         }
         guard create.statusCode == 201, let id = decodeId(create.body) else {
@@ -69,6 +155,10 @@ enum KubernetesProvisioner {
             throw K8sError.createFailed(createFailureDetail(start.body))
         }
 
+        try await waitUntilReady(runtime: runtime, progress: progress)
+    }
+
+    private static func waitUntilReady(runtime: any ContainerRuntime, progress: @Sendable (String) -> Void) async throws {
         progress("Waiting for the node to become Ready…")
         var lastProbe = ""
         for attempt in 0..<90 {
@@ -95,20 +185,98 @@ enum KubernetesProvisioner {
 
     static func disable(runtime: any ContainerRuntime) async {
         await deleteExisting(runtime)
+        removeFromDefaultKubeconfig()
         try? FileManager.default.removeItem(atPath: kubeconfigPath)
     }
 
-    static func createJSON(image: String) -> String {
-        """
-        {"Image":"\(image)",\
-        "Cmd":["server","--disable=traefik","--tls-san=127.0.0.1","--tls-san=host.docker.internal"],\
-        "ExposedPorts":{"\(apiPort)/tcp":{}},\
-        "HostConfig":{"Privileged":true,"PortBindings":{"\(apiPort)/tcp":[{"HostPort":"\(apiPort)"}]}}}
-        """
+    static func createJSON(image: String, extraPorts: [PortPublish] = [], registriesBind: String? = nil) -> String {
+        String(decoding: createBody(image: image, extraPorts: extraPorts, registriesBind: registriesBind), as: UTF8.self)
     }
 
-    private static func createBody(image: String) -> Data {
-        Data(createJSON(image: image).utf8)
+    static func loadExtraPorts(path: String? = nil) throws -> [PortPublish] {
+        let file = path ?? extraPortsConfigPath
+        guard let content = try? String(contentsOfFile: file, encoding: .utf8) else { return [] }
+        var ports: [PortPublish] = []
+        for (index, line) in content.components(separatedBy: .newlines).enumerated() {
+            guard !PortPublish.normalizedConfigText(line).isEmpty else { continue }
+            guard let port = PortPublish.parse(line) else {
+                throw K8sError.invalidPortConfig(path: file, line: index + 1, value: line)
+            }
+            ports.append(port)
+        }
+        return ports
+    }
+
+    /// The host registries.yaml to bind into the node, when the user has created one. The home
+    /// directory is shared into the VM at the same path (SharedVMProvisioner), so the host path is
+    /// directly bind-mountable by the VM's dockerd.
+    static func registriesBindSource() -> String? {
+        FileManager.default.fileExists(atPath: registriesConfigPath) ? registriesConfigPath : nil
+    }
+
+    /// Rename k3s' generic `default` cluster/user/context to `dory`. k3s.yaml is single-entry with
+    /// a stable shape, so targeted textual rewrites are sufficient and dependency-free.
+    static func renameContext(_ kubeconfig: String) -> String {
+        kubeconfig.components(separatedBy: "\n").map(renameContextLine).joined(separator: "\n")
+    }
+
+    private static func createBody(image: String, extraPorts: [PortPublish], registriesBind: String?) -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return (try? encoder.encode(createRequest(image: image, extraPorts: extraPorts, registriesBind: registriesBind))) ?? Data()
+    }
+
+    private static func createRequest(image: String, extraPorts: [PortPublish], registriesBind: String?) -> KubernetesCreateRequest {
+        var exposed: [String: DockerEmptyObject] = [:]
+        var bindings: [String: [DockerPortBinding]] = [:]
+        addPortBinding(PortPublish(host: apiPort, container: apiPort, proto: "tcp"), exposed: &exposed, bindings: &bindings)
+        for port in extraPorts {
+            addPortBinding(port, exposed: &exposed, bindings: &bindings)
+        }
+        return KubernetesCreateRequest(
+            Image: image,
+            Cmd: ["server", "--disable=traefik", "--tls-san=127.0.0.1", "--tls-san=host.docker.internal"],
+            ExposedPorts: exposed,
+            HostConfig: .init(
+                Privileged: true,
+                PortBindings: bindings,
+                Binds: registriesBind.map { [registriesBindValue(source: $0)] }
+            )
+        )
+    }
+
+    private static func addPortBinding(_ port: PortPublish, exposed: inout [String: DockerEmptyObject], bindings: inout [String: [DockerPortBinding]]) {
+        let key = "\(port.container)/\(port.proto)"
+        let hostPort = "\(port.host)"
+        exposed[key] = DockerEmptyObject()
+        var existing = bindings[key] ?? []
+        if !existing.contains(where: { $0.HostPort == hostPort }) {
+            existing.append(DockerPortBinding(HostPort: hostPort))
+        }
+        bindings[key] = existing
+    }
+
+    private static func registriesBindValue(source: String) -> String {
+        "\(source):\(registriesBindTarget):ro"
+    }
+
+    private static func renameContextLine(_ line: String) -> String {
+        let hasCarriageReturn = line.hasSuffix("\r")
+        let body = hasCarriageReturn ? String(line.dropLast()) : line
+        let replacements = ["name", "cluster", "user", "current-context"]
+        for key in replacements {
+            let suffix = "\(key): default"
+            guard body.hasSuffix(suffix) else { continue }
+            let prefix = body.dropLast(suffix.count)
+            // k3s' users list nests the key in a sequence item ("- name: default"),
+            // so allow one trailing sequence marker on top of the indent.
+            var indent = prefix
+            if indent.hasSuffix("- ") { indent = indent.dropLast(2) }
+            guard indent.allSatisfy({ $0 == " " || $0 == "\t" }) else { continue }
+            let renamed = "\(prefix)\(key): \(contextName)"
+            return hasCarriageReturn ? "\(renamed)\r" : renamed
+        }
+        return line
     }
 
     private static func writeKubeconfig(_ runtime: any ContainerRuntime) async throws {
@@ -117,14 +285,142 @@ enum KubernetesProvisioner {
         // k3s.yaml already targets 127.0.0.1:6443, which the port forwarder makes host-reachable.
         let directory = (kubeconfigPath as NSString).deletingLastPathComponent
         try? FileManager.default.createDirectory(atPath: directory, withIntermediateDirectories: true)
-        try result.output.write(toFile: kubeconfigPath, atomically: true, encoding: .utf8)
+        try renameContext(result.output).write(toFile: kubeconfigPath, atomically: true, encoding: .utf8)
+        mergeIntoDefaultKubeconfig()
     }
 
-    private static func isRunning(_ runtime: any ContainerRuntime) async -> Bool {
+    /// kubectl used for the kubeconfig merge/unmerge — resolved through HostTools so the copy
+    /// bundled in the app wins and packaged installs merge without any system kubectl.
+    static func hostKubectl() -> String? { HostTools.kubectl() }
+
+    /// Fold the side-file context into `~/.kube/config` via kubectl itself — dory hand-rolls its
+    /// YAML and must never rewrite the file holding the user's other cluster credentials. Stale
+    /// `dory` entries are deleted before the merge because KUBECONFIG precedence favors the first
+    /// file: after a cluster recreate (fresh certs) the old entries would otherwise win. The main
+    /// config leads the chain so the user's `current-context` is preserved when set. No kubectl on
+    /// the host, or a merge failure, leaves the main config untouched — the side file remains the
+    /// documented fallback.
+    private static func mergeIntoDefaultKubeconfig() {
+        guard let kubectl = hostKubectl() else { return }
+        let main = defaultKubeconfigPath
+        deleteDoryEntries(kubectl: kubectl, from: main)
+        let merged = runKubectl(kubectl, ["config", "view", "--flatten", "--raw"],
+                                kubeconfigChain: "\(main):\(kubeconfigPath)")
+        guard merged.ok, merged.stdout.contains("server:") else { return }
+        let tmp = "\(main).dory.tmp"
+        do {
+            try merged.stdout.write(toFile: tmp, atomically: true, encoding: .utf8)
+            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: tmp)
+            if FileManager.default.fileExists(atPath: main) {
+                _ = try FileManager.default.replaceItemAt(URL(fileURLWithPath: main), withItemAt: URL(fileURLWithPath: tmp))
+            } else {
+                try FileManager.default.moveItem(atPath: tmp, toPath: main)
+            }
+        } catch {
+            try? FileManager.default.removeItem(atPath: tmp)
+        }
+    }
+
+    /// Undo the merge on disable: drop the `dory` entries and, when the user had switched to it,
+    /// the now-dangling `current-context`.
+    private static func removeFromDefaultKubeconfig() {
+        let main = defaultKubeconfigPath
+        guard let kubectl = hostKubectl(), FileManager.default.fileExists(atPath: main) else { return }
+        let current = runKubectl(kubectl, ["--kubeconfig", main, "config", "current-context"])
+        if current.ok, current.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == contextName {
+            _ = runKubectl(kubectl, ["--kubeconfig", main, "config", "unset", "current-context"])
+        }
+        deleteDoryEntries(kubectl: kubectl, from: main)
+    }
+
+    private static func deleteDoryEntries(kubectl: String, from main: String) {
+        for subcommand in ["delete-context", "delete-cluster", "delete-user"] {
+            _ = runKubectl(kubectl, ["--kubeconfig", main, "config", subcommand, contextName])
+        }
+    }
+
+    /// kubectl runner with stdout kept clean (Shell's helpers fold stderr in, which would corrupt
+    /// the flattened YAML) and optional KUBECONFIG override (the only way to hand kubectl a
+    /// multi-file chain).
+    private static func runKubectl(_ kubectl: String, _ arguments: [String], kubeconfigChain: String? = nil) -> (stdout: String, ok: Bool) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: kubectl)
+        process.arguments = arguments
+        if let kubeconfigChain {
+            var environment = ProcessInfo.processInfo.environment
+            environment["KUBECONFIG"] = kubeconfigChain
+            process.environment = environment
+        }
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+        do { try process.run() } catch { return ("", false) }
+        let data = stdout.fileHandleForReading.readDataToEndOfFile()
+        _ = stderr.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return (String(data: data, encoding: .utf8) ?? "", process.terminationStatus == 0)
+    }
+
+    private static func existingContainerState(_ runtime: any ContainerRuntime) async -> ExistingContainerState {
         let encodedName = DockerImageOps.pathComponent(containerName)
         guard let response = await runtime.proxyRequest(method: "GET", path: "/containers/\(encodedName)/json", headers: [], body: Data()),
-              response.isSuccess else { return false }
-        return String(data: response.body, encoding: .utf8)?.contains("\"Running\":true") ?? false
+              response.isSuccess else { return .absent }
+        guard let inspect = try? JSONDecoder().decode(ContainerInspect.self, from: response.body) else { return .absent }
+        return inspect.State?.running == true ? .running : .stopped
+    }
+
+    /// Whether the existing container already publishes every requested extra port and carries the
+    /// registries.yaml bind when one is configured, so an enable with unchanged config can reuse it
+    /// instead of recreating (both are fixed at create).
+    private static func publishedPortsCurrent(_ runtime: any ContainerRuntime, extraPorts: [PortPublish]) async -> Bool {
+        let registriesBind = registriesBindSource()
+        let encodedName = DockerImageOps.pathComponent(containerName)
+        guard let response = await runtime.proxyRequest(method: "GET", path: "/containers/\(encodedName)/json", headers: [], body: Data()),
+              response.isSuccess, let json = String(data: response.body, encoding: .utf8) else { return false }
+        return inspectJSONCoversConfig(json, extraPorts: extraPorts, registriesBind: registriesBind)
+    }
+
+    static func inspectJSONCoversConfig(_ json: String, extraPorts: [PortPublish], registriesBind: String?) -> Bool {
+        guard let data = json.data(using: .utf8),
+              let inspect = try? JSONDecoder().decode(ContainerInspect.self, from: data) else { return false }
+        guard let hostConfig = inspect.HostConfig,
+              let actualPorts = actualExtraPorts(from: hostConfig.PortBindings ?? [:]) else { return false }
+        let desiredRegistryBinds = Set(registriesBind.map { [registriesBindValue(source: $0)] } ?? [])
+        let actualRegistryBinds = Set((hostConfig.Binds ?? []).filter(isRegistriesBind))
+        return actualPorts == desiredExtraPorts(extraPorts) && actualRegistryBinds == desiredRegistryBinds
+    }
+
+    private static func desiredExtraPorts(_ ports: [PortPublish]) -> Set<PortPublish> {
+        Set(ports.filter { !isBuiltInAPIBinding($0) })
+    }
+
+    private static func actualExtraPorts(from bindings: [String: [ContainerInspect.PortBinding]]) -> Set<PortPublish>? {
+        var ports = Set<PortPublish>()
+        for (key, hostBindings) in bindings {
+            let parts = key.split(separator: "/", maxSplits: 1, omittingEmptySubsequences: false)
+            guard parts.count == 2,
+                  let container = Int(parts[0]),
+                  !parts[1].isEmpty else { return nil }
+            let proto = String(parts[1])
+            for binding in hostBindings {
+                guard let hostPort = binding.HostPort,
+                      let host = Int(hostPort) else { return nil }
+                let port = PortPublish(host: host, container: container, proto: proto)
+                if !isBuiltInAPIBinding(port) {
+                    ports.insert(port)
+                }
+            }
+        }
+        return ports
+    }
+
+    private static func isBuiltInAPIBinding(_ port: PortPublish) -> Bool {
+        port.host == apiPort && port.container == apiPort && port.proto == "tcp"
+    }
+
+    private static func isRegistriesBind(_ bind: String) -> Bool {
+        bind.contains(":\(registriesBindTarget):") || bind.hasSuffix(":\(registriesBindTarget)")
     }
 
     private static func deleteExisting(_ runtime: any ContainerRuntime) async {
@@ -166,7 +462,19 @@ enum KubernetesProvisioner {
         }
     }
 
-    private struct ContainerInspect: Decodable, Sendable { let State: ContainerState? }
+    private struct ContainerInspect: Decodable, Sendable {
+        let State: ContainerState?
+        let HostConfig: HostConfig?
+
+        struct HostConfig: Decodable, Sendable {
+            let Binds: [String]?
+            let PortBindings: [String: [PortBinding]]?
+        }
+
+        struct PortBinding: Decodable, Sendable {
+            let HostPort: String?
+        }
+    }
 
     private static func containerState(_ runtime: any ContainerRuntime) async -> ContainerState? {
         let encodedName = DockerImageOps.pathComponent(containerName)
@@ -189,4 +497,5 @@ enum KubernetesProvisioner {
         struct Out: Decodable { let Id: String }
         return (try? JSONDecoder().decode(Out.self, from: data))?.Id
     }
+
 }

--- a/DoryTests/KubeContextHintTests.swift
+++ b/DoryTests/KubeContextHintTests.swift
@@ -2,9 +2,14 @@ import Testing
 @testable import Dory
 
 struct KubeContextHintTests {
-    @Test func snippetContainsExportAndPath() {
-        let snippet = KubeContextHint.snippet(kubeconfigPath: "/Users/x/.kube/dory-config")
+    @Test func mergedSnippetIsContextOnly() {
+        let snippet = KubeContextHint.snippet(kubeconfigPath: "/Users/x/.kube/dory-config", merged: true)
+        #expect(snippet == "kubectl --context dory get pods -A")
+    }
+
+    @Test func sideFileSnippetKeepsExportAndPath() {
+        let snippet = KubeContextHint.snippet(kubeconfigPath: "/Users/x/.kube/dory-config", merged: false)
         #expect(snippet.contains("export KUBECONFIG=/Users/x/.kube/dory-config"))
-        #expect(snippet.contains("kubectl get pods"))
+        #expect(snippet.contains("kubectl --context dory get pods -A"))
     }
 }

--- a/DoryTests/KubernetesProvisionerImageTests.swift
+++ b/DoryTests/KubernetesProvisionerImageTests.swift
@@ -3,16 +3,278 @@ import Testing
 @testable import Dory
 
 struct KubernetesProvisionerImageTests {
+    private struct CreateBody: Decodable {
+        let Image: String
+        let Cmd: [String]
+        let ExposedPorts: [String: EmptyObject]
+        let HostConfig: HostConfig
+
+        struct EmptyObject: Decodable {}
+
+        struct HostConfig: Decodable {
+            let Privileged: Bool
+            let PortBindings: [String: [PortBinding]]
+            let Binds: [String]?
+        }
+
+        struct PortBinding: Decodable {
+            let HostPort: String
+            let HostIp: String?
+        }
+    }
+
     @Test func defaultImageIsCatalogLatest() {
         #expect(KubernetesProvisioner.defaultImage == KubeVersionCatalog.latest.image)
     }
 
-    @Test func createJSONInterpolatesTheGivenImage() {
+    @Test func createJSONEncodesStructuredCreateBody() throws {
         let image = KubeVersionCatalog.all[2].image
-        let json = KubernetesProvisioner.createJSON(image: image)
-        #expect(json.contains("\"Image\":\"\(image)\""))
-        #expect(json.contains("\"server\""))
-        #expect(json.contains("--disable=traefik"))
-        #expect(json.contains("PortBindings"))
+        let body = try decodeCreateBody(KubernetesProvisioner.createJSON(image: image))
+        #expect(body.Image == image)
+        #expect(body.Cmd == ["server", "--disable=traefik", "--tls-san=127.0.0.1", "--tls-san=host.docker.internal"])
+        #expect(Array(body.ExposedPorts.keys).sorted() == ["6443/tcp"])
+        #expect((body.HostConfig.PortBindings["6443/tcp"] ?? []).map(\.HostPort) == ["6443"])
+        #expect(body.HostConfig.Privileged)
+        #expect(body.HostConfig.Binds == nil)
+    }
+
+    @Test func createJSONPublishesExtraPortsAlongsideAPI() throws {
+        let ports = [KubernetesProvisioner.PortPublish(host: 30500, container: 30500, proto: "tcp")]
+        let body = try decodeCreateBody(KubernetesProvisioner.createJSON(image: KubernetesProvisioner.defaultImage, extraPorts: ports))
+        #expect(Array(body.ExposedPorts.keys).sorted() == ["30500/tcp", "6443/tcp"])
+        #expect((body.HostConfig.PortBindings["30500/tcp"] ?? []).map(\.HostPort) == ["30500"])
+        #expect((body.HostConfig.PortBindings["6443/tcp"] ?? []).map(\.HostPort) == ["6443"])
+    }
+
+    @Test func createJSONMergesRepeatedContainerProtoBindings() throws {
+        let ports = [
+            KubernetesProvisioner.PortPublish(host: 30500, container: 80, proto: "tcp"),
+            KubernetesProvisioner.PortPublish(host: 30501, container: 80, proto: "tcp"),
+            KubernetesProvisioner.PortPublish(host: 30500, container: 80, proto: "tcp"),
+        ]
+        let body = try decodeCreateBody(KubernetesProvisioner.createJSON(image: KubernetesProvisioner.defaultImage, extraPorts: ports))
+        let hostPorts = (body.HostConfig.PortBindings["80/tcp"] ?? []).map(\.HostPort).sorted()
+        #expect(hostPorts == ["30500", "30501"])
+        #expect(body.ExposedPorts["80/tcp"] != nil)
+    }
+
+    @Test func createJSONKeepsExtraAPIPortBindingWhenHostDiffers() throws {
+        let ports = [
+            KubernetesProvisioner.PortPublish(host: 6443, container: 6443, proto: "tcp"),
+            KubernetesProvisioner.PortPublish(host: 16443, container: 6443, proto: "tcp"),
+        ]
+        let body = try decodeCreateBody(KubernetesProvisioner.createJSON(image: KubernetesProvisioner.defaultImage, extraPorts: ports))
+        let hostPorts = (body.HostConfig.PortBindings["6443/tcp"] ?? []).map(\.HostPort).sorted()
+        #expect(hostPorts == ["16443", "6443"])
+    }
+
+    @Test func createJSONEscapesImageAndRegistriesBind() throws {
+        let image = "registry.example.com/team/ki\"nd:dev\\test"
+        let bind = "/Users/me/Application Support/\"dory\"\\registries.yaml"
+        let body = try decodeCreateBody(
+            KubernetesProvisioner.createJSON(
+                image: image,
+                registriesBind: bind
+            )
+        )
+        #expect(body.Image == image)
+        #expect(body.HostConfig.Binds == ["\(bind):/etc/rancher/k3s/registries.yaml:ro"])
+    }
+
+    @Test func portPublishParsesLinesAndSkipsCommentsAndGarbage() {
+        #expect(KubernetesProvisioner.PortPublish.parse("30500:30500")
+            == KubernetesProvisioner.PortPublish(host: 30500, container: 30500, proto: "tcp"))
+        #expect(KubernetesProvisioner.PortPublish.parse("30500:30500\r")
+            == KubernetesProvisioner.PortPublish(host: 30500, container: 30500, proto: "tcp"))
+        #expect(KubernetesProvisioner.PortPublish.parse("30500:30500 # registry")
+            == KubernetesProvisioner.PortPublish(host: 30500, container: 30500, proto: "tcp"))
+        #expect(KubernetesProvisioner.PortPublish.parse("  8080 : 80 / udp # service ")
+            == KubernetesProvisioner.PortPublish(host: 8080, container: 80, proto: "udp"))
+        #expect(KubernetesProvisioner.PortPublish.parse("  8080:80/udp ")
+            == KubernetesProvisioner.PortPublish(host: 8080, container: 80, proto: "udp"))
+        #expect(KubernetesProvisioner.PortPublish.parse("# comment") == nil)
+        #expect(KubernetesProvisioner.PortPublish.parse("") == nil)
+        #expect(KubernetesProvisioner.PortPublish.parse("30500") == nil)
+        #expect(KubernetesProvisioner.PortPublish.parse("a:b") == nil)
+        #expect(KubernetesProvisioner.PortPublish.parse("0:70000") == nil)
+        #expect(KubernetesProvisioner.PortPublish.parse("80:80/sctp") == nil)
+    }
+
+    @Test func loadExtraPortsStripsInlineComments() throws {
+        let url = temporaryFileURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        try """
+        30500:30500 # registry
+        # full-line comment
+
+          8080 : 80 / udp # service
+        """.write(to: url, atomically: true, encoding: .utf8)
+
+        #expect(try KubernetesProvisioner.loadExtraPorts(path: url.path) == [
+            KubernetesProvisioner.PortPublish(host: 30500, container: 30500, proto: "tcp"),
+            KubernetesProvisioner.PortPublish(host: 8080, container: 80, proto: "udp"),
+        ])
+    }
+
+    @Test func loadExtraPortsThrowsOnInvalidNonCommentLines() throws {
+        let url = temporaryFileURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        try """
+        # comment
+        invalid
+        """.write(to: url, atomically: true, encoding: .utf8)
+
+        do {
+            _ = try KubernetesProvisioner.loadExtraPorts(path: url.path)
+            Issue.record("expected invalid port config error")
+        } catch KubernetesProvisioner.K8sError.invalidPortConfig(let path, let line, let value) {
+            #expect(path == url.path)
+            #expect(line == 2)
+            #expect(value == "invalid")
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+    }
+
+    @Test func inspectJSONMatchesHostPortOnTheRequestedContainerPort() {
+        let desired = [KubernetesProvisioner.PortPublish(host: 30500, container: 30500, proto: "tcp")]
+        let crossed = """
+        {"HostConfig":{"PortBindings":{
+          "30500/tcp":[{"HostPort":"30501"}],
+          "30501/tcp":[{"HostPort":"30500"}]
+        }}}
+        """
+        let matching = """
+        {"HostConfig":{"PortBindings":{
+          "30500/tcp":[{"HostPort":"30500"}]
+        }}}
+        """
+
+        #expect(!KubernetesProvisioner.inspectJSONCoversConfig(crossed, extraPorts: desired, registriesBind: nil))
+        #expect(KubernetesProvisioner.inspectJSONCoversConfig(matching, extraPorts: desired, registriesBind: nil))
+    }
+
+    @Test func inspectJSONDetectsRemovedExtraPorts() {
+        let desired = [KubernetesProvisioner.PortPublish(host: 30500, container: 30500, proto: "tcp")]
+        let builtInOnly = """
+        {"HostConfig":{"PortBindings":{
+          "6443/tcp":[{"HostPort":"6443"}]
+        }}}
+        """
+        let staleActual = """
+        {"HostConfig":{"PortBindings":{
+          "6443/tcp":[{"HostPort":"6443"}],
+          "30500/tcp":[{"HostPort":"30500"}]
+        }}}
+        """
+
+        #expect(!KubernetesProvisioner.inspectJSONCoversConfig(builtInOnly, extraPorts: desired, registriesBind: nil))
+        #expect(!KubernetesProvisioner.inspectJSONCoversConfig(staleActual, extraPorts: [], registriesBind: nil))
+        #expect(KubernetesProvisioner.inspectJSONCoversConfig(builtInOnly, extraPorts: [], registriesBind: nil))
+    }
+
+    @Test func inspectJSONIgnoresOnlyTheBuiltInAPIBinding() {
+        let desired = [KubernetesProvisioner.PortPublish(host: 16443, container: 6443, proto: "tcp")]
+        let matching = """
+        {"HostConfig":{"PortBindings":{
+          "6443/tcp":[{"HostPort":"6443"},{"HostPort":"16443"}]
+        }}}
+        """
+        let removed = """
+        {"HostConfig":{"PortBindings":{
+          "6443/tcp":[{"HostPort":"6443"}]
+        }}}
+        """
+
+        #expect(KubernetesProvisioner.inspectJSONCoversConfig(matching, extraPorts: desired, registriesBind: nil))
+        #expect(!KubernetesProvisioner.inspectJSONCoversConfig(removed, extraPorts: desired, registriesBind: nil))
+    }
+
+    @Test func inspectJSONRequiresExactRegistriesBindSource() {
+        let expected = "/Users/me/.dory/k8s/registries.yaml"
+        let wrong = """
+        {"HostConfig":{"Binds":[
+          "/Users/me/.dory/k8s/registries.yaml.bak:/etc/rancher/k3s/registries.yaml:ro"
+        ],"PortBindings":{}}}
+        """
+        let matching = """
+        {"HostConfig":{"Binds":[
+          "/Users/me/.dory/k8s/registries.yaml:/etc/rancher/k3s/registries.yaml:ro"
+        ],"PortBindings":{}}}
+        """
+
+        #expect(!KubernetesProvisioner.inspectJSONCoversConfig(wrong, extraPorts: [], registriesBind: expected))
+        #expect(KubernetesProvisioner.inspectJSONCoversConfig(matching, extraPorts: [], registriesBind: expected))
+    }
+
+    @Test func inspectJSONDetectsRemovedRegistriesBind() {
+        let staleActual = """
+        {"HostConfig":{"Binds":[
+          "/Users/me/.dory/k8s/registries.yaml:/etc/rancher/k3s/registries.yaml:ro"
+        ],"PortBindings":{}}}
+        """
+        let desired = "/Users/me/.dory/k8s/registries.yaml"
+        let noActual = #"{"HostConfig":{"Binds":[],"PortBindings":{}}}"#
+
+        #expect(!KubernetesProvisioner.inspectJSONCoversConfig(staleActual, extraPorts: [], registriesBind: nil))
+        #expect(!KubernetesProvisioner.inspectJSONCoversConfig(noActual, extraPorts: [], registriesBind: desired))
+    }
+
+    @Test func renameContextRewritesAllDefaultNames() {
+        let k3sYaml = """
+        apiVersion: v1
+        clusters:
+        - cluster:
+            server: https://127.0.0.1:6443
+          name: default
+        contexts:
+        - context:
+            cluster: default
+            user: default
+          name: default
+        current-context: default
+        kind: Config
+        users:
+        - name: default
+          user:
+            client-certificate-data: abc
+        """
+        let renamed = KubernetesProvisioner.renameContext(k3sYaml)
+        #expect(!renamed.contains("default"))
+        #expect(renamed.contains("name: dory"))
+        #expect(renamed.contains("cluster: dory"))
+        #expect(renamed.contains("user: dory"))
+        #expect(renamed.contains("current-context: dory"))
+        #expect(renamed.contains("client-certificate-data: abc"))
+    }
+
+    @Test func renameContextLeavesUnrelatedDefaultTextUntouched() {
+        let k3sYaml = """
+        apiVersion: v1
+        users:
+        - name: default
+          user:
+            username: default
+            note: name: default
+            comment: user: default
+        current-context: default
+        # user: default
+        """
+        let renamed = KubernetesProvisioner.renameContext(k3sYaml)
+        #expect(renamed.contains("username: default"))
+        #expect(renamed.contains("note: name: default"))
+        #expect(renamed.contains("comment: user: default"))
+        #expect(renamed.contains("# user: default"))
+        #expect(renamed.contains("- name: dory"))
+        #expect(renamed.contains("current-context: dory"))
+    }
+
+    private func decodeCreateBody(_ json: String) throws -> CreateBody {
+        try JSONDecoder().decode(CreateBody.self, from: Data(json.utf8))
+    }
+
+    private func temporaryFileURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("dory-k8s-ports-\(UUID().uuidString)")
     }
 }

--- a/README.md
+++ b/README.md
@@ -278,8 +278,31 @@ The native browser covers:
 - services, ConfigMaps, Secrets, and Ingresses;
 - namespace filtering, YAML apply, rollout status, and kubeconfig copy.
 
-The component-managed `kubectl` and `dory k8s <kubectl args...>` target the same cluster. k3s has its own image
-store, so push a built image to a registry or import it into the cluster before using it in a Pod.
+The component-managed `kubectl` and `dory k8s <kubectl args...>` target the same cluster. Use
+`dory k8s enable|disable|status` to manage the cluster from scripts or CI. Kubectl merges a named
+`dory` context into `~/.kube/config` without changing other entries or the current context, and
+disable removes it again. If kubectl is unavailable or the merge fails, the kubeconfig remains at
+`~/.kube/dory-config` for use through `KUBECONFIG`.
+
+Two optional host-side files extend the cluster without the GUI:
+
+- `~/.dory/k8s/ports` publishes extra ports on the cluster container, one
+  `HOST:CONTAINER[/proto]` per line, so NodePorts can become host-reachable.
+- `~/.dory/k8s/registries.yaml` supplies k3s' native registry mirror and trust configuration.
+
+Both files survive cluster recreation. Ports and binds are fixed when the container is created;
+changing them is reported as drift and is never applied destructively. Run `dory k8s enable` with
+`--recreate` or disable and re-enable Kubernetes in the app to apply the change. The command also
+accepts repeatable `--publish HOST:CONTAINER[/proto]` options and `--image` to pin the k3s image.
+Add `--no-kubeconfig-merge` to leave `~/.kube/config` untouched and use only the
+`~/.kube/dory-config` side file for CI or deliberately isolated `KUBECONFIG` setups.
+
+```sh
+kubectl --context dory get pods -A
+```
+
+k3s has its own image store, so push a built image to a registry or import it into the cluster before
+using it in a Pod.
 
 ## Dory Linux machines
 

--- a/scripts/dory
+++ b/scripts/dory
@@ -17,6 +17,7 @@ DORY_SCRIPT_DIR="$(cd -P "$(dirname "$DORY_SCRIPT_SOURCE")" >/dev/null 2>&1 && p
 
 DORY_CLI_VERSION="0.0.0-dev"
 DORY_SOCK="${DORY_SOCK:-$HOME/.dory/dory.sock}"
+ENGINE_SOCK="${DORY_ENGINE_SOCK:-$HOME/.dory/engine.sock}"
 KUBECONFIG_DORY="$HOME/.kube/dory-config"
 RECIPE_DIR="${DORY_RECIPE_DIR:-$HOME/.dory/recipes}"
 BUILTIN_RECIPE_DIR="${DORY_BUILTIN_RECIPE_DIR:-$(cd "$DORY_SCRIPT_DIR/.." && pwd)/Dory/Resources/Recipes}"
@@ -44,6 +45,12 @@ DOCKER_BUILDX_BIN="${DORY_DOCKER_BUILDX_BIN:-$(resolve_cli docker-buildx || prin
 DOCKER_COMPOSE_BIN="${DORY_DOCKER_COMPOSE_BIN:-$(resolve_cli docker-compose || printf '%s\n' docker-compose)}"
 KUBECTL_BIN="${DORY_KUBECTL_BIN:-$(resolve_cli kubectl || printf '%s\n' kubectl)}"
 
+K8S_NAME="dory-k8s"
+K8S_IMAGE="${DORY_K8S_IMAGE:-rancher/k3s:v1.36.2-k3s1}"   # keep in sync with KubeVersionCatalog.latest
+K8S_DIR="$HOME/.dory/k8s"
+K8S_CONTEXT="dory"
+DK_FALLBACK_WARNED=0
+
 host_guest_arch() {
   [ "$(uname -m)" = "x86_64" ] && printf '%s\n' "amd64" || printf '%s\n' "arm64"
 }
@@ -66,6 +73,255 @@ hv_helper() {
            "$DORY_SCRIPT_DIR/../Packages/ContainerizationEngine/.build/out/Products/Debug/dory-hv"; do
     [ -n "$p" ] && [ -x "$p" ] && { echo "$p"; return; }
   done
+}
+
+# docker against Dory's engine (prefer the raw engine socket, like the app does).
+dk() {
+  if [ -S "$ENGINE_SOCK" ]; then
+    docker -H "unix://$ENGINE_SOCK" "$@"
+  else
+    if [ "$DK_FALLBACK_WARNED" -eq 0 ]; then
+      echo "warning: $ENGINE_SOCK not found; falling back to $DORY_SOCK. Kubernetes will be created on the proxied daemon; hops requires engine.sock." >&2
+      DK_FALLBACK_WARNED=1
+    fi
+    docker -H "unix://$DORY_SOCK" "$@"
+  fi
+}
+
+k8s_normalize_port() {
+  local raw="$1" p ports proto hport cport
+  p="$(printf '%s' "${raw%%#*}" | tr -d '[:space:]')"
+  [ -n "$p" ] || return 1
+  case "$p" in
+    */*) ports="${p%/*}"; proto="${p##*/}" ;;
+    *)   ports="$p"; proto="tcp" ;;
+  esac
+  case "$proto" in tcp|udp) ;; *) return 1 ;; esac
+  case "$ports" in *:*) hport="${ports%%:*}"; cport="${ports#*:}" ;; *) return 1 ;; esac
+  [[ "$hport" =~ ^[0-9]+$ ]] || return 1
+  [[ "$cport" =~ ^[0-9]+$ ]] || return 1
+  (( 10#$hport >= 1 && 10#$hport <= 65535 )) || return 1
+  (( 10#$cport >= 1 && 10#$cport <= 65535 )) || return 1
+  printf '%s:%s/%s\n' "$hport" "$cport" "$proto"
+}
+
+# Extra port publishings for the k8s node: `--publish H:C[/proto]` flags plus one entry per line in
+# ~/.dory/k8s/ports (comments allowed). Kept in sync with KubernetesProvisioner's file format.
+k8s_desired_ports() {
+  local p normalized
+  for p in ${K8S_PUBLISHES:-}; do
+    normalized="$(k8s_normalize_port "$p")" || {
+      echo "error: invalid port publishing '$p' (expected H:C[/tcp|udp], ports 1-65535)" >&2
+      return 2
+    }
+    echo "$normalized"
+  done
+  if [ -f "$K8S_DIR/ports" ]; then
+    while IFS= read -r p || [ -n "$p" ]; do
+      normalized="$(k8s_normalize_port "$p")" || {
+        [ -z "$(printf '%s' "${p%%#*}" | tr -d '[:space:]')" ] && continue
+        echo "error: invalid port publishing in $K8S_DIR/ports: '$p' (expected H:C[/tcp|udp], ports 1-65535)" >&2
+        return 2
+      }
+      echo "$normalized"
+    done < "$K8S_DIR/ports"
+  fi
+}
+
+k8s_canonical_ports() {
+  local p
+  while IFS= read -r p; do
+    [ -n "$p" ] || continue
+    [ "$p" = "6443:6443/tcp" ] && continue
+    printf '%s\n' "$p"
+  done | LC_ALL=C sort -u
+}
+
+k8s_actual_ports() {
+  dk inspect -f '{{range $key, $bindings := .HostConfig.PortBindings}}{{range $bindings}}{{if .HostPort}}{{.HostPort}}:{{$key}}{{"\n"}}{{end}}{{end}}{{end}}' "$K8S_NAME" 2>/dev/null
+}
+
+k8s_desired_registries_bind() {
+  [ -f "$K8S_DIR/registries.yaml" ] && printf '%s\n' "$K8S_DIR/registries.yaml:/etc/rancher/k3s/registries.yaml:ro"
+  return 0
+}
+
+k8s_actual_registries_bind() {
+  dk inspect -f '{{range .HostConfig.Binds}}{{println .}}{{end}}' "$K8S_NAME" 2>/dev/null \
+    | grep -E ':/etc/rancher/k3s/registries\.yaml(:|$)' \
+    | LC_ALL=C sort -u || true
+}
+
+# Emits create-time config drift details and returns non-zero when drift exists.
+k8s_config_drift() {
+  local state="$1" desired_ports="$2" drift=0 actual_ports desired_registry actual_registry
+  desired_ports="$(printf '%s\n' "$desired_ports" | k8s_canonical_ports)"
+  actual_ports="$(k8s_actual_ports | k8s_canonical_ports)" || {
+    echo "  - published ports could not be inspected"
+    drift=1
+  }
+  if [ "${actual_ports:-}" != "$desired_ports" ]; then
+    echo "  - published ports differ"
+    echo "    desired: ${desired_ports:-none}"
+    echo "    actual: ${actual_ports:-none}"
+    drift=1
+  fi
+  desired_registry="$(k8s_desired_registries_bind)"
+  actual_registry="$(k8s_actual_registries_bind)"
+  if [ "$actual_registry" != "$desired_registry" ]; then
+    echo "  - registries.yaml bind differs"
+    echo "    desired: ${desired_registry:-none}"
+    echo "    actual: ${actual_registry:-none}"
+    drift=1
+  fi
+  return "$drift"
+}
+
+k8s_write_kubeconfig() {
+  mkdir -p "$HOME/.kube"
+  # k3s.yaml targets 127.0.0.1:6443 (host-reachable via Dory's port forwarder); rename the generic
+  # `default` cluster/user/context to `dory` so tools can address the cluster by context name.
+  # The optional `- ` covers YAML sequence items (k3s' users list: `- name: default`).
+  dk exec "$K8S_NAME" cat /etc/rancher/k3s/k3s.yaml \
+    | sed -e "s/^\([[:space:]]*\(- \)\{0,1\}\)name: default$/\1name: $K8S_CONTEXT/" \
+          -e "s/^\([[:space:]]*\(- \)\{0,1\}\)cluster: default$/\1cluster: $K8S_CONTEXT/" \
+          -e "s/^\([[:space:]]*\(- \)\{0,1\}\)user: default$/\1user: $K8S_CONTEXT/" \
+          -e "s/^current-context: default$/current-context: $K8S_CONTEXT/" \
+    > "$KUBECONFIG_DORY"
+  chmod 600 "$KUBECONFIG_DORY"
+  if [ "${K8S_MERGE:-1}" -eq 1 ]; then
+    k8s_merge_kubeconfig
+  else
+    echo "note: kubeconfig merge skipped; to use the cluster: export KUBECONFIG=$KUBECONFIG_DORY"
+  fi
+}
+
+# Fold the dory context into ~/.kube/config via kubectl itself — never hand-edit the file
+# holding the user's other cluster credentials. Stale dory entries are deleted before the
+# merge because KUBECONFIG precedence favors the FIRST file: after a cluster recreate
+# (fresh certs) the old entries would otherwise win. The main config leads the chain so the
+# user's current-context is preserved when set. No kubectl, or a failed merge, leaves the
+# main config untouched and the side file remains the documented fallback.
+k8s_merge_kubeconfig() {
+  local main tmp
+  main="$HOME/.kube/config"
+  if ! command -v kubectl >/dev/null 2>&1; then
+    echo "note: kubectl not found; to use the cluster: export KUBECONFIG=$KUBECONFIG_DORY"
+    return 0
+  fi
+  kubectl --kubeconfig "$main" config delete-context "$K8S_CONTEXT" >/dev/null 2>&1 || true
+  kubectl --kubeconfig "$main" config delete-cluster "$K8S_CONTEXT" >/dev/null 2>&1 || true
+  kubectl --kubeconfig "$main" config delete-user "$K8S_CONTEXT" >/dev/null 2>&1 || true
+  tmp="$(mktemp "$HOME/.kube/.config.dory.XXXXXX")" || return 0
+  if KUBECONFIG="$main:$KUBECONFIG_DORY" kubectl config view --flatten --raw >"$tmp" 2>/dev/null \
+     && grep -q 'server:' "$tmp"; then
+    chmod 600 "$tmp"
+    mv "$tmp" "$main"
+  else
+    rm -f "$tmp"
+    echo "warning: merging into $main failed; to use the cluster: export KUBECONFIG=$KUBECONFIG_DORY" >&2
+  fi
+}
+
+k8s_wait_ready() {
+  local i
+  for i in $(seq 1 90); do
+    if dk exec "$K8S_NAME" kubectl get nodes --no-headers 2>/dev/null | grep -q ' Ready'; then
+      k8s_write_kubeconfig
+      echo "Kubernetes is running (context: $K8S_CONTEXT)"
+      return 0
+    fi
+    sleep 2
+  done
+  echo "error: k3s node did not become Ready; try 'dory k8s disable && dory k8s enable'" >&2
+  return 1
+}
+
+k8s_enable() {
+  K8S_PUBLISHES=""
+  local recreate=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --publish|-p) [ $# -ge 2 ] || { echo "usage: dory k8s enable [--recreate] [--no-kubeconfig-merge] [--publish H:C[/proto]]... [--image IMG]" >&2; exit 2; }
+                    K8S_PUBLISHES="$K8S_PUBLISHES $2"; shift 2 ;;
+      --image)      [ $# -ge 2 ] || { echo "usage: dory k8s enable [--recreate] [--no-kubeconfig-merge] [--publish H:C[/proto]]... [--image IMG]" >&2; exit 2; }
+                    K8S_IMAGE="$2"; shift 2 ;;
+      --recreate)   recreate=1; shift ;;
+      --no-kubeconfig-merge) K8S_MERGE=0; shift ;;
+      *) echo "usage: dory k8s enable [--recreate] [--no-kubeconfig-merge] [--publish H:C[/proto]]... [--image IMG]" >&2; exit 2 ;;
+    esac
+  done
+  mkdir -p "$K8S_DIR"
+
+  local desired_ports state drift
+  desired_ports="$(k8s_desired_ports | k8s_canonical_ports)" || exit $?
+  state="$(dk inspect -f '{{.State.Running}}' "$K8S_NAME" 2>/dev/null || echo absent)"
+  if [ "$state" != "absent" ]; then
+    if drift="$(k8s_config_drift "$state" "$desired_ports")"; then
+      # Reuse the container: bindings are fixed at create and they already match.
+      [ "$state" = "true" ] || dk start "$K8S_NAME" >/dev/null
+      k8s_wait_ready
+      return
+    fi
+    if [ "$recreate" -ne 1 ]; then
+      echo "error: Kubernetes create-time config drift detected:" >&2
+      printf '%s\n' "$drift" >&2
+      echo "re-run with --recreate to apply (destroys cluster state)" >&2
+      exit 3
+    fi
+  fi
+
+  echo "Creating Kubernetes (k3s) container '$K8S_NAME'..."
+  dk rm -f "$K8S_NAME" >/dev/null 2>&1 || true
+  set -- run -d --name "$K8S_NAME" --privileged -p "6443:6443"
+  local p
+  while IFS= read -r p; do
+    [ -n "$p" ] && set -- "$@" -p "$p"
+  done <<EOF
+$desired_ports
+EOF
+  # k3s' native registry mirror/trust config; host-side so it survives recreation (read at boot).
+  [ -f "$K8S_DIR/registries.yaml" ] && set -- "$@" -v "$K8S_DIR/registries.yaml:/etc/rancher/k3s/registries.yaml:ro"
+  set -- "$@" "$K8S_IMAGE" server --disable=traefik --tls-san=127.0.0.1 --tls-san=host.docker.internal
+  dk "$@" >/dev/null
+  k8s_wait_ready
+}
+
+k8s_disable() {
+  dk rm -f "$K8S_NAME" >/dev/null 2>&1 || true
+  k8s_unmerge_kubeconfig
+  rm -f "$KUBECONFIG_DORY"
+  echo "Kubernetes disabled"
+}
+
+# Undo the merge: drop the dory entries and, when the user had switched to it, the
+# now-dangling current-context.
+k8s_unmerge_kubeconfig() {
+  local main current
+  main="$HOME/.kube/config"
+  command -v kubectl >/dev/null 2>&1 || return 0
+  [ -f "$main" ] || return 0
+  current="$(kubectl --kubeconfig "$main" config current-context 2>/dev/null || true)"
+  if [ "$current" = "$K8S_CONTEXT" ]; then
+    kubectl --kubeconfig "$main" config unset current-context >/dev/null 2>&1 || true
+  fi
+  kubectl --kubeconfig "$main" config delete-context "$K8S_CONTEXT" >/dev/null 2>&1 || true
+  kubectl --kubeconfig "$main" config delete-cluster "$K8S_CONTEXT" >/dev/null 2>&1 || true
+  kubectl --kubeconfig "$main" config delete-user "$K8S_CONTEXT" >/dev/null 2>&1 || true
+}
+
+k8s_status() {
+  local state
+  state="$(dk inspect -f '{{.State.Running}}' "$K8S_NAME" 2>/dev/null || true)"
+  case "$state" in
+    true)
+      if dk exec "$K8S_NAME" kubectl get nodes --no-headers 2>/dev/null | grep -q ' Ready'; then
+        echo "running (node Ready, context: $K8S_CONTEXT)"; exit 0
+      fi
+      echo "starting (node not Ready yet)"; exit 1 ;;
+    false) echo "stopped"; exit 1 ;;
+    *)     echo "not created"; exit 1 ;;
+  esac
 }
 
 usage() {
@@ -166,6 +422,17 @@ dory — Dory CLI
   dory usb ls                   Inspect host USB candidates (passthrough is not yet available)
   dory expose <port|machine> [--port P] [--hostname H] [--print-command]
                                Share a local port or machine endpoint through a public HTTPS tunnel
+  dory k8s enable [--recreate] [--no-kubeconfig-merge] [--publish H:C[/proto]]... [--image IMG]
+                               Start the built-in k3s cluster (headless). Also reads
+                               ~/.dory/k8s/ports (one H:C[/proto] per line) and bind-mounts
+                               ~/.dory/k8s/registries.yaml when present. --recreate applies
+                               create-time config drift and destroys cluster state.
+                               --no-kubeconfig-merge leaves ~/.kube/config untouched
+                               (side file + export KUBECONFIG only).
+  dory k8s disable             Delete the cluster container and its kubeconfig (reserved only
+                               with no trailing args; otherwise passed to kubectl)
+  dory k8s status              Cluster state (reserved only with no trailing args; otherwise
+                               passed to kubectl; exit 0 when the node is Ready)
   dory k8s <kubectl args...>   Run kubectl against Dory's Kubernetes cluster
   dory ssh <machine>           SSH into a Linux machine as you (real ssh when available)
   dory vm [--image R] [--arch amd64|arm64] [--rosetta] [--mount h:g] -- <cmd>
@@ -5160,10 +5427,26 @@ case "${1:-help}" in
                   fi ;;
   vm)             shift; H="$(vmm_helper || true)"; [ -z "$H" ] && { echo "dory-vmm helper not found; build+sign it (see scripts/bundle-engine.sh)" >&2; exit 1; }; exec "$H" "$@" ;;
   k8s)            shift
-                  if ! [ -x "$KUBECTL_BIN" ] && ! command -v "$KUBECTL_BIN" >/dev/null 2>&1; then
-                    echo "Kubernetes is not installed. Run: dory component install kubernetes" >&2
-                    exit 1
-                  fi
-                  exec "$KUBECTL_BIN" --kubeconfig "$KUBECONFIG_DORY" "$@" ;;
+                  case "${1:-}" in
+                    enable)  shift; k8s_enable "$@" ;;
+                    disable) shift; if [ $# -eq 0 ]; then k8s_disable; else
+                               if ! [ -x "$KUBECTL_BIN" ] && ! command -v "$KUBECTL_BIN" >/dev/null 2>&1; then
+                                 echo "Kubernetes is not installed. Run: dory component install kubernetes" >&2
+                                 exit 1
+                               fi
+                               exec "$KUBECTL_BIN" --kubeconfig "$KUBECONFIG_DORY" disable "$@"; fi ;;
+                    status)  shift; if [ $# -eq 0 ]; then k8s_status; else
+                               if ! [ -x "$KUBECTL_BIN" ] && ! command -v "$KUBECTL_BIN" >/dev/null 2>&1; then
+                                 echo "Kubernetes is not installed. Run: dory component install kubernetes" >&2
+                                 exit 1
+                               fi
+                               exec "$KUBECTL_BIN" --kubeconfig "$KUBECONFIG_DORY" status "$@"; fi ;;
+                    *)
+                      if ! [ -x "$KUBECTL_BIN" ] && ! command -v "$KUBECTL_BIN" >/dev/null 2>&1; then
+                        echo "Kubernetes is not installed. Run: dory component install kubernetes" >&2
+                        exit 1
+                      fi
+                      exec "$KUBECTL_BIN" --kubeconfig "$KUBECONFIG_DORY" "$@" ;;
+                  esac ;;
   *)              exec "$DOCKER_BIN" -H "unix://$DORY_SOCK" "$@" ;;
 esac


### PR DESCRIPTION
Adds four small, composable extension points to the built-in Kubernetes cluster so it can be driven and configured from scripts and CI — no GUI interaction required. Everything is opt-in; with no config files present and no CLI usage, behavior is unchanged.

## 1. Headless cluster lifecycle: `dory k8s enable|disable|status`

New CLI subcommands in `scripts/dory` manage the k3s cluster container directly against the engine socket, mirroring what the app's toggle does:

- `dory k8s enable [--publish HOST:CONTAINER[/proto]] [--recreate]` — creates (or reuses/restarts) the `dory-k8s` container, waits for node Ready, and writes the kubeconfig. Port specs are validated (1–65535, tcp/udp).
- `dory k8s disable` — removes the container and kubeconfig (and unmerges the `dory` context, see 4).
- `dory k8s status` — reports container state, published ports, and config drift.

If the running container's actual state (published ports, bind mounts — checked via inspect, not a cached state file) no longer matches the requested config, `enable` exits with code 3 and a clear message instead of silently reusing a stale cluster or destructively recreating a running one. `--recreate` opts in to the recreate. The app's enable path throws the same drift error (`K8sError.configDrift`) and surfaces "disable and re-enable to apply".

## 2. Extra port publishings: `~/.dory/k8s/ports`

One `HOST:CONTAINER[/proto]` per line (comments and blanks ignored). These are published on the cluster container at create, so the existing port forwarder makes them reachable on `localhost` — which makes k3s NodePorts host-reachable, e.g. `30500:30500` for an in-cluster registry.

## 3. Registry config: `~/.dory/k8s/registries.yaml`

When present, this file is bind-mounted read-only to `/etc/rancher/k3s/registries.yaml` — k3s' native mirror/trust configuration, read at boot. Living on the host, it survives the cluster container being recreated. This is the standard way to let the cluster pull from private/insecure registries — and the mechanism behind the "push it to a registry the cluster can reach" guidance the provisioner docs added for #4.

## 4. `dory` context, merged into `~/.kube/config`

k3s' generic `default` cluster/user/context is renamed to `dory`, and the context is **merged into `~/.kube/config`** — so right after enable:

```sh
kubectl --context dory get pods -A
```

just works, with zero `KUBECONFIG` setup — same UX as docker-desktop, orbstack, and colima. Mechanics:

- **kubectl does the merge** (the bundled copy, resolved via `HostTools`, so packaged installs need nothing installed): `kubectl config view --flatten --raw` over a `main:side` chain, written atomically at 0600. Dory never hand-rewrites the file holding your other clusters' credentials.
- Your existing entries and `current-context` are always preserved (the main config leads the chain); stale `dory` entries are deleted before merging so fresh certs win after a cluster recreate.
- `disable` unmerges: removes the `dory` context/cluster/user and unsets a dangling `current-context`.
- No kubectl available, or the merge fails → the side file `~/.kube/dory-config` remains the documented fallback (`export KUBECONFIG=...`), and the main config is left untouched.
- **Opt out entirely with `dory k8s enable --no-kubeconfig-merge`** — keeps `~/.kube/config` untouched and uses only the side file, for CI or deliberately isolated `KUBECONFIG` setups. `disable`'s unmerge only deletes `dory`-named entries, so it's a safe no-op when the context was never merged.

⚠️ **Migration note:** anything referencing the old `default` context in `~/.kube/dory-config` needs to switch to `--context dory` (and no longer needs the `KUBECONFIG` export when kubectl is present).

Both the app (`KubernetesProvisioner`) and the CLI read the same config files and share identical merge/drift semantics, so GUI- and script-managed clusters stay consistent.

## Tests

- `DoryTests/KubernetesProvisionerImageTests.swift` extended: port parsing/validation, structured create-body encoding, context rename (including YAML sequence items like `- name: default`), inspect-based exact-set drift coverage (removals included).
- `DoryTests/KubeContextHintTests.swift`: merged and side-file hint forms.
- Kubeconfig merge/unmerge verified live against real kubectl with fixture configs: stale `dory` entries replaced, foreign clusters + `current-context` preserved, dangling `current-context` unset on disable, first-ever `~/.kube/config` created correctly.
- Verified end to end: cluster create with published NodePort + registries.yaml bind, image pull from an in-cluster registry, stop/start resume, drift detection on config change.
- Rebased onto current `main` (dory-hv engine); full suite green with the CI recipe (`test.sh -skip-testing:DoryUITests`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added built-in Kubernetes enable/disable/status support with kubeconfig context merging.
  * Added support for extra port mappings and optional registry mount configuration when starting Kubernetes.
  * Added clearer cluster status reporting, including startup and drift conditions.

* **Bug Fixes**
  * Improved kubeconfig handling so the Kubernetes context is explicitly targeted.
  * Better detects configuration changes and avoids silently reusing mismatched setups.
  * Updated user-facing error handling for configuration drift.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->