### PR TITLE
fix: reconcile stale gvproxy port forwards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,6 +166,7 @@ scripts/__pycache__/
 #codex
 .codex-bench/
 .dory-build/
+.gstack/
 
 # Internal planning and qualification documents
 /ARCHITECTURE.md

--- a/Packages/ContainerizationEngine/Package.swift
+++ b/Packages/ContainerizationEngine/Package.swift
@@ -48,6 +48,7 @@ let package = Package(
             name: "DoryHVTests",
             dependencies: [
                 "DoryHV",
+                "dory-hv",
                 .product(name: "DoryCore", package: "dory-core-swift"),
             ]
         ),

--- a/Packages/ContainerizationEngine/Sources/DoryHV/GVProxyForwardRegistry.swift
+++ b/Packages/ContainerizationEngine/Sources/DoryHV/GVProxyForwardRegistry.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+package enum GVProxyForwardRegistry {
+    package static func publishedForwards(
+        from data: Data,
+        guestIP: String
+    ) -> Set<PublishedPortForward>? {
+        guard let entries = try? JSONDecoder().decode([Entry].self, from: data) else {
+            return nil
+        }
+        return Set(entries.compactMap { entry in
+            guard let protocolValue = PublishedPortForwardProtocol(rawValue: entry.protocol),
+                  let local = Endpoint(entry.local),
+                  let remote = Endpoint(entry.remote),
+                  remote.normalizedHost == Endpoint.normalizedHost(guestIP),
+                  local.port == PublishedPortForwardPlan.localPort(forPublishedPort: remote.port) else {
+                return nil
+            }
+            return PublishedPortForward(
+                protocol: protocolValue,
+                publishedPort: remote.port,
+                localHost: local.host,
+                localPort: local.port,
+                guestHost: guestIP,
+                guestPort: remote.port
+            )
+        })
+    }
+
+    private struct Entry: Decodable {
+        let local: String
+        let remote: String
+        let `protocol`: String
+    }
+
+    private struct Endpoint {
+        let host: String
+        let port: Int
+
+        var normalizedHost: String { Self.normalizedHost(host) }
+
+        init?(_ rawValue: String) {
+            let value: Substring
+            if let scheme = rawValue.range(of: "://") {
+                value = rawValue[scheme.upperBound...]
+            } else {
+                value = rawValue[...]
+            }
+
+            let host: Substring
+            let portText: Substring
+            if value.first == "[" {
+                guard let closingBracket = value.firstIndex(of: "]"),
+                      value.index(after: closingBracket) < value.endIndex,
+                      value[value.index(after: closingBracket)] == ":" else {
+                    return nil
+                }
+                host = value[...closingBracket]
+                portText = value[value.index(closingBracket, offsetBy: 2)...]
+            } else {
+                guard let separator = value.lastIndex(of: ":") else { return nil }
+                host = value[..<separator]
+                portText = value[value.index(after: separator)...]
+            }
+
+            guard !host.isEmpty,
+                  let port = Int(portText),
+                  (1...65_535).contains(port) else {
+                return nil
+            }
+            self.host = String(host)
+            self.port = port
+        }
+
+        static func normalizedHost(_ value: String) -> String {
+            value.trimmingCharacters(in: CharacterSet(charactersIn: "[]")).lowercased()
+        }
+    }
+}
+
+package struct GVProxyForwardReconciliation {
+    package let observed: Set<PublishedPortForward>
+    package let toExpose: Set<PublishedPortForward>
+    package let toUnexpose: Set<PublishedPortForward>
+
+    package init(
+        wanted: Set<PublishedPortForward>,
+        actual: Set<PublishedPortForward>?,
+        cached: Set<PublishedPortForward>,
+        protected: Set<PublishedPortForward> = []
+    ) {
+        let current = actual ?? cached
+        // Machine-port watcher forwards share gvproxy with Docker publication, but are owned by a
+        // separate event stream. Keep them out of Docker's stale-forward cleanup unless Docker also
+        // wants the exact same forward.
+        observed = current.subtracting(protected.subtracting(wanted))
+        toExpose = wanted.subtracting(observed)
+        toUnexpose = observed.subtracting(wanted)
+    }
+}

--- a/Packages/ContainerizationEngine/Sources/dory-hv/EngineMode.swift
+++ b/Packages/ContainerizationEngine/Sources/dory-hv/EngineMode.swift
@@ -3,6 +3,66 @@ import DoryHV
 import Foundation
 import Synchronization
 
+package final class PortReconcileSignalRegistration: @unchecked Sendable {
+    private let lock = NSLock()
+    private let worker = DispatchQueue(label: "dev.dory.hv.port-reconcile-signal")
+    private let workerKey = DispatchSpecificKey<Void>()
+    private let reconcile: @Sendable () -> Void
+    private var source: (any DispatchSourceSignal)?
+
+    package init(reconcile: @escaping @Sendable () -> Void) {
+        self.reconcile = reconcile
+        worker.setSpecific(key: workerKey, value: ())
+    }
+
+    package func install() {
+        lock.lock()
+        guard source == nil else {
+            lock.unlock()
+            return
+        }
+        _ = signal(SIGUSR2, SIG_IGN)
+        let source = DispatchSource.makeSignalSource(signal: SIGUSR2, queue: worker)
+        source.setEventHandler { [weak self] in
+            guard let self else { return }
+            reconcile()
+        }
+        self.source = source
+        source.resume()
+        lock.unlock()
+    }
+
+    /// Waits for an already-delivered signal handler to finish before inspecting reconciliation
+    /// effects or beginning shutdown cleanup.
+    package func waitUntilIdle() {
+        drainWorker()
+    }
+
+    package func cancel() {
+        lock.lock()
+        let source = source
+        self.source = nil
+        lock.unlock()
+        guard let source else { return }
+
+        source.setEventHandler {}
+        source.cancel()
+        drainWorker()
+        // This defer runs before gvproxy cleanup. Keep late repair requests harmless until exit.
+        _ = signal(SIGUSR2, SIG_IGN)
+    }
+
+    private func drainWorker() {
+        if DispatchQueue.getSpecific(key: workerKey) == nil {
+            worker.sync {}
+        }
+    }
+
+    deinit {
+        cancel()
+    }
+}
+
 /// `dory-hv engine`: the production mode SharedVMProvisioner spawns. Owns the full lifecycle:
 /// pulls docker:dind once, boots the VMM with networking, and publishes the Docker API at the
 /// unix socket the app already consumes.
@@ -137,15 +197,15 @@ enum EngineMode {
         signalSources.append(source)
     }
 
-    private static func installPortReconcileSignal(portForwarder: PortForwarder) {
-        signal(SIGUSR2, SIG_IGN)
-        let source = DispatchSource.makeSignalSource(signal: SIGUSR2, queue: .global())
-        source.setEventHandler {
+    package static func installPortReconcileSignal(
+        portForwarder: PortForwarder
+    ) -> PortReconcileSignalRegistration {
+        let registration = PortReconcileSignalRegistration {
             note("manual port reconcile requested")
             portForwarder.reconcileNow()
         }
-        source.resume()
-        signalSources.append(source)
+        registration.install()
+        return registration
     }
 
     private static func syncGuestClock(
@@ -636,7 +696,8 @@ enum EngineMode {
             bridgeSubnetCIDR: bridgeNetwork.cidr,
             log: { note($0) }
         )
-        installPortReconcileSignal(portForwarder: portForwarder)
+        let portReconcileSignal = installPortReconcileSignal(portForwarder: portForwarder)
+        defer { portReconcileSignal.cancel() }
         portForwarder.start()
         let gvproxyDatapathTask = monitorGVProxyDatapath(
             healthSocket: gvproxyHealthSocket,

--- a/Packages/ContainerizationEngine/Sources/dory-hv/PortForwarder.swift
+++ b/Packages/ContainerizationEngine/Sources/dory-hv/PortForwarder.swift
@@ -18,9 +18,18 @@ final class PortForwarder: MachinePortForwarding, @unchecked Sendable {
     private let sourcePreservingLANGVProxySocketPath: String?
     private let bridgeSubnetCIDR: String
     private let log: (String) -> Void
+    private let publishedPortsProvider: (() -> Set<PublishedPortBinding>?)?
+    private let registeredForwardsProvider: (() -> Set<PublishedPortForward>?)?
+    private let exposeProvider: ((PublishedPortForward) -> Bool)?
+    private let unexposeProvider: ((PublishedPortForward) -> Bool)?
     private let queue = DispatchQueue(label: "dev.dory.hv.port-forwarder")
+    private let queueKey = DispatchSpecificKey<Void>()
     private let timer: any DispatchSourceTimer
+    private let timerLock = NSLock()
+    private var timerActivated = false
+    private var timerCancelled = false
     private var exposed = Set<PublishedPortForward>()
+    private var machineExposed = Set<PublishedPortForward>()
     private var lastForwardFailureLog: [PublishedPortForward: Date] = [:]
     private var lastLANFailureLog = Date.distantPast
     private var recoveringLANSession = false
@@ -34,7 +43,11 @@ final class PortForwarder: MachinePortForwarding, @unchecked Sendable {
         sourcePreservingLANSessionID: String? = nil,
         sourcePreservingLANGVProxySocketPath: String? = nil,
         bridgeSubnetCIDR: String = DoryIPv4BridgeNetwork.defaultCIDR,
-        log: @escaping (String) -> Void
+        log: @escaping (String) -> Void,
+        publishedPortsProvider: (() -> Set<PublishedPortBinding>?)? = nil,
+        registeredForwardsProvider: (() -> Set<PublishedPortForward>?)? = nil,
+        exposeProvider: ((PublishedPortForward) -> Bool)? = nil,
+        unexposeProvider: ((PublishedPortForward) -> Bool)? = nil
     ) {
         self.engineSocket = engineSocket
         self.apiSocket = apiSocket
@@ -45,17 +58,51 @@ final class PortForwarder: MachinePortForwarding, @unchecked Sendable {
         self.sourcePreservingLANGVProxySocketPath = sourcePreservingLANGVProxySocketPath
         self.bridgeSubnetCIDR = bridgeSubnetCIDR
         self.log = log
+        self.publishedPortsProvider = publishedPortsProvider
+        self.registeredForwardsProvider = registeredForwardsProvider
+        self.exposeProvider = exposeProvider
+        self.unexposeProvider = unexposeProvider
         self.timer = DispatchSource.makeTimerSource(queue: queue)
+        queue.setSpecific(key: queueKey, value: ())
         timer.schedule(deadline: .now() + 3, repeating: 2)
         timer.setEventHandler { [weak self] in self?.sync() }
     }
 
-    func start() { timer.resume() }
+    func start() {
+        timerLock.lock()
+        defer { timerLock.unlock() }
+        guard !timerActivated, !timerCancelled else { return }
+        timerActivated = true
+        timer.resume()
+    }
 
-    /// Coalesces manual repair with the normal two-second reconciliation loop on the same serial
-    /// queue, keeping the tracked forward set race-free.
+    package func stop() {
+        timerLock.lock()
+        guard !timerCancelled else {
+            timerLock.unlock()
+            return
+        }
+        timer.setEventHandler {}
+        if !timerActivated {
+            timerActivated = true
+            timer.resume()
+        }
+        timerCancelled = true
+        timer.cancel()
+        timerLock.unlock()
+        if DispatchQueue.getSpecific(key: queueKey) == nil {
+            queue.sync {}
+        }
+    }
+
+    deinit {
+        stop()
+    }
+
+    /// Runs manual repair on the normal reconciliation queue and returns after gvproxy operations
+    /// finish, keeping the tracked forward set race-free and tests deterministic.
     func reconcileNow() {
-        queue.async { [weak self] in self?.sync() }
+        queue.sync { sync() }
     }
 
     private func sync() {
@@ -82,7 +129,14 @@ final class PortForwarder: MachinePortForwarding, @unchecked Sendable {
             publishHost: loopbackPolicy,
             guestIP: guestIP
         )
-        for forward in wanted.subtracting(exposed) {
+        let reconciliation = GVProxyForwardReconciliation(
+            wanted: wanted,
+            actual: registeredPublishedForwards(),
+            cached: exposed,
+            protected: machineExposed
+        )
+        exposed = reconciliation.observed
+        for forward in reconciliation.toExpose {
             if expose(forward) {
                 exposed.insert(forward)
                 lastForwardFailureLog.removeValue(forKey: forward)
@@ -97,7 +151,7 @@ final class PortForwarder: MachinePortForwarding, @unchecked Sendable {
         }
         // Only forget the port once gvproxy confirms the forward is gone; a failed unexpose stays
         // tracked and is retried on the next tick, so a stale host forward can't leak.
-        for forward in exposed.subtracting(wanted) where unexpose(forward) {
+        for forward in reconciliation.toUnexpose where unexpose(forward) {
             exposed.remove(forward)
             lastForwardFailureLog.removeValue(forKey: forward)
             log("port forward: released \(forward.localEndpoint)/\(forward.protocol.rawValue)")
@@ -144,6 +198,7 @@ final class PortForwarder: MachinePortForwarding, @unchecked Sendable {
 
     /// The set of host ports currently published by any running container.
     private func publishedPorts() -> Set<PublishedPortBinding>? {
+        if let publishedPortsProvider { return publishedPortsProvider() }
         guard let data = curlData(unixSocket: engineSocket, url: "http://d/v1.41/containers/json"),
               let containers = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
             return nil
@@ -179,6 +234,7 @@ final class PortForwarder: MachinePortForwarding, @unchecked Sendable {
     }
 
     private func expose(_ forward: PublishedPortForward) -> Bool {
+        if let exposeProvider { return exposeProvider(forward) }
         // gvproxy's TCP forward wants a bare host:port remote (no scheme), unlike the unix-socket
         // forward used for the docker socket.
         return curlPost(unixSocket: apiSocket, url: "http://gvproxy/services/forwarder/expose",
@@ -190,6 +246,7 @@ final class PortForwarder: MachinePortForwarding, @unchecked Sendable {
     }
 
     private func unexpose(_ forward: PublishedPortForward) -> Bool {
+        if let unexposeProvider { return unexposeProvider(forward) }
         return curlPost(unixSocket: apiSocket, url: "http://gvproxy/services/forwarder/unexpose",
                         body: gvproxyBody(
                             local: forward.localEndpoint,
@@ -198,13 +255,54 @@ final class PortForwarder: MachinePortForwarding, @unchecked Sendable {
     }
 
     func exposeMachinePort(_ port: UInt16) async -> Bool {
-        let binding = PublishedPortBinding(protocol: .tcp, port: Int(port))
-        return expose(PublishedPortForwardPlan.forward(for: binding, localHost: localHost, guestIP: guestIP))
+        await withCheckedContinuation { continuation in
+            queue.async { [weak self] in
+                guard let self else {
+                    continuation.resume(returning: false)
+                    return
+                }
+                let binding = PublishedPortBinding(protocol: .tcp, port: Int(port))
+                let forward = PublishedPortForwardPlan.forward(
+                    for: binding,
+                    localHost: self.localHost,
+                    guestIP: self.guestIP
+                )
+                let exposed = self.expose(forward)
+                if exposed { self.machineExposed.insert(forward) }
+                continuation.resume(returning: exposed)
+            }
+        }
     }
 
     func unexposeMachinePort(_ port: UInt16) async -> Bool {
-        let binding = PublishedPortBinding(protocol: .tcp, port: Int(port))
-        return unexpose(PublishedPortForwardPlan.forward(for: binding, localHost: localHost, guestIP: guestIP))
+        await withCheckedContinuation { continuation in
+            queue.async { [weak self] in
+                guard let self else {
+                    continuation.resume(returning: false)
+                    return
+                }
+                let binding = PublishedPortBinding(protocol: .tcp, port: Int(port))
+                let forward = PublishedPortForwardPlan.forward(
+                    for: binding,
+                    localHost: self.localHost,
+                    guestIP: self.guestIP
+                )
+                let unexposed = self.unexpose(forward)
+                if unexposed { self.machineExposed.remove(forward) }
+                continuation.resume(returning: unexposed)
+            }
+        }
+    }
+
+    private func registeredPublishedForwards() -> Set<PublishedPortForward>? {
+        if let registeredForwardsProvider { return registeredForwardsProvider() }
+        guard let data = curlData(
+            unixSocket: apiSocket,
+            url: "http://gvproxy/services/forwarder/all"
+        ) else {
+            return nil
+        }
+        return GVProxyForwardRegistry.publishedForwards(from: data, guestIP: guestIP)
     }
 
     private func curlData(unixSocket: String, url: String) -> Data? {

--- a/Packages/ContainerizationEngine/Tests/DoryHVTests/GVProxyForwardRegistryTests.swift
+++ b/Packages/ContainerizationEngine/Tests/DoryHVTests/GVProxyForwardRegistryTests.swift
@@ -1,0 +1,165 @@
+import Foundation
+import Testing
+@testable import DoryHV
+@testable import dory_hv
+
+@Suite(.serialized) struct GVProxyForwardRegistryTests {
+    @Test func decodesOnlyContainerPublishedForwardsFromBundledGVProxyRegistry() throws {
+        let data = Data(#"""
+        [
+          {"local":"127.0.0.1:2222","remote":"192.168.127.2:22","protocol":"tcp"},
+          {"local":"127.0.0.1:55120","remote":"192.168.127.2:55120","protocol":"tcp"},
+          {"local":"[::1]:5353","remote":"192.168.127.2:5353","protocol":"udp"},
+          {"local":"/tmp/dory.sock","remote":"tcp://192.168.127.2:2377","protocol":"unix"}
+        ]
+        """#.utf8)
+
+        #expect(GVProxyForwardRegistry.publishedForwards(
+            from: data,
+            guestIP: "192.168.127.2"
+        ) == [
+            forward(.tcp, host: "127.0.0.1", port: 55_120),
+            forward(.udp, host: "[::1]", port: 5_353),
+        ])
+    }
+
+    @Test func sigusr2RepairsMissingAndOrphanedForwardsUsingActualGVProxyState() {
+        let previousSIGUSR2Handler = signal(SIGUSR2, SIG_IGN)
+        _ = signal(SIGUSR2, previousSIGUSR2Handler)
+        let missing = forward(.tcp, host: "127.0.0.1", port: 55_999)
+        let orphan = forward(.tcp, host: "127.0.0.1", port: 55_120)
+        let calls = ForwardCallRecorder()
+        let registry = ForwardRegistryStub([missing])
+        let forwarder = PortForwarder(
+            engineSocket: "/unused/engine.sock",
+            apiSocket: "/unused/gvproxy.sock",
+            guestIP: "192.168.127.2",
+            log: { _ in },
+            publishedPortsProvider: {
+                [PublishedPortBinding(
+                    protocol: .tcp,
+                    port: missing.publishedPort,
+                    hostIP: "127.0.0.1"
+                )]
+            },
+            registeredForwardsProvider: { registry.current },
+            exposeProvider: { calls.recordExpose($0); return true },
+            unexposeProvider: { calls.recordUnexpose($0); return true }
+        )
+        defer {
+            _ = signal(SIGUSR2, previousSIGUSR2Handler)
+            forwarder.stop()
+        }
+
+        // Seed the forwarder's in-memory cache while Docker and gvproxy agree. Then mutate only
+        // gvproxy to reproduce issue #45: the desired forward disappears behind the stale cache,
+        // while an unrelated orphan appears without ever entering that cache.
+        forwarder.reconcileNow()
+        #expect(calls.exposed.isEmpty)
+        #expect(calls.unexposed.isEmpty)
+
+        registry.current = [orphan]
+        let signalRegistration = EngineMode.installPortReconcileSignal(portForwarder: forwarder)
+        #expect(kill(getpid(), SIGUSR2) == 0)
+        #expect(calls.waitForOperations(count: 2))
+        signalRegistration.waitUntilIdle()
+
+        #expect(calls.exposed == [missing])
+        #expect(calls.unexposed == [orphan])
+
+        signalRegistration.cancel()
+        #expect(kill(getpid(), SIGUSR2) == 0)
+    }
+
+    @Test func machineForwardOwnershipIsSerializedAndProtectedFromDockerCleanup() async {
+        let machine = forward(.tcp, host: "127.0.0.1", port: 57_000)
+        let calls = ForwardCallRecorder()
+        let forwarder = PortForwarder(
+            engineSocket: "/unused/engine.sock",
+            apiSocket: "/unused/gvproxy.sock",
+            guestIP: "192.168.127.2",
+            log: { _ in },
+            publishedPortsProvider: { [] },
+            registeredForwardsProvider: { [machine] },
+            exposeProvider: { calls.recordExpose($0); return true },
+            unexposeProvider: { calls.recordUnexpose($0); return true }
+        )
+
+        forwarder.start()
+        #expect(await forwarder.exposeMachinePort(57_000))
+        forwarder.reconcileNow()
+
+        #expect(calls.exposed == [machine])
+        #expect(calls.unexposed.isEmpty)
+    }
+
+    @Test func malformedRegistryFailsClosed() {
+        #expect(GVProxyForwardRegistry.publishedForwards(
+            from: Data("not-json".utf8),
+            guestIP: "192.168.127.2"
+        ) == nil)
+    }
+
+    private func forward(
+        _ protocolValue: PublishedPortForwardProtocol,
+        host: String,
+        port: Int
+    ) -> PublishedPortForward {
+        PublishedPortForward(
+            protocol: protocolValue,
+            publishedPort: port,
+            localHost: host,
+            localPort: port,
+            guestHost: "192.168.127.2",
+            guestPort: port
+        )
+    }
+}
+
+private final class ForwardRegistryStub: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: Set<PublishedPortForward>
+
+    init(_ forwards: Set<PublishedPortForward>) {
+        stored = forwards
+    }
+
+    var current: Set<PublishedPortForward> {
+        get { lock.withLock { stored } }
+        set { lock.withLock { stored = newValue } }
+    }
+}
+
+private final class ForwardCallRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private let operationCompleted = DispatchSemaphore(value: 0)
+    private var storedExposed = Set<PublishedPortForward>()
+    private var storedUnexposed = Set<PublishedPortForward>()
+
+    var exposed: Set<PublishedPortForward> {
+        lock.withLock { storedExposed }
+    }
+
+    var unexposed: Set<PublishedPortForward> {
+        lock.withLock { storedUnexposed }
+    }
+
+    func recordExpose(_ forward: PublishedPortForward) {
+        _ = lock.withLock { storedExposed.insert(forward) }
+        operationCompleted.signal()
+    }
+
+    func recordUnexpose(_ forward: PublishedPortForward) {
+        _ = lock.withLock { storedUnexposed.insert(forward) }
+        operationCompleted.signal()
+    }
+
+    func waitForOperations(count: Int) -> Bool {
+        for _ in 0..<count {
+            guard operationCompleted.wait(timeout: .now() + 2) == .success else {
+                return false
+            }
+        }
+        return true
+    }
+}


### PR DESCRIPTION
## Summary

- Reconcile Docker-published ports against gvproxy's live `/services/forwarder/all` registry instead of treating dory-hv's in-memory cache as authoritative.
- Repair missing listeners and remove orphaned forwards through the production `SIGUSR2` path, while keeping late repair signals harmless during shutdown.
- Serialize machine-port ownership with Docker reconciliation so unrelated machine forwards are not removed.
- Ignore local `.gstack/` runtime state and credentials.

Fixes #45

## Test coverage

- Added a deterministic regression test that seeds a stale in-memory cache, mutates the simulated live gvproxy registry, sends real `SIGUSR2`, and verifies the missing and orphaned forwards are repaired.
- Added coverage for gvproxy registry parsing, malformed responses, machine-forward protection, and late `SIGUSR2` delivery after signal-handler cancellation.

## Verification

- `swift test --no-parallel --package-path Packages/ContainerizationEngine --filter GVProxyForwardRegistryTests.sigusr2RepairsMissingAndOrphanedForwardsUsingActualGVProxyState`
  - 1 test passed.
- `swift test --no-parallel --package-path Packages/ContainerizationEngine`
  - 519 tests across 65 suites passed.
- Targeted pre-landing re-review found no P0-P2 issues.
