### PR TITLE
Fix clean-runner UI test startup

### DIFF
--- a/DoryUITests/DoryScreensUITests.swift
+++ b/DoryUITests/DoryScreensUITests.swift
@@ -15,6 +15,13 @@ final class DoryScreensUITests: XCTestCase {
             _ = app.wait(for: .notRunning, timeout: 5)
         }
         app.launch()
+
+        // Sparkle asks for update-check consent on a clean macOS user account. Hosted runners are
+        // clean on every job, so dismiss that product-owned prompt before exercising Dory's UI.
+        let declineAutomaticChecks = app.buttons["Don’t Check"]
+        if declineAutomaticChecks.waitForExistence(timeout: 2) {
+            declineAutomaticChecks.click()
+        }
     }
 
     override func tearDownWithError() throws {

--- a/DoryUITests/DoryScreensUITests.swift
+++ b/DoryUITests/DoryScreensUITests.swift
@@ -18,7 +18,7 @@ final class DoryScreensUITests: XCTestCase {
 
         // Sparkle asks for update-check consent on a clean macOS user account. Hosted runners are
         // clean on every job, so dismiss that product-owned prompt before exercising Dory's UI.
-        let declineAutomaticChecks = app.buttons["Don’t Check"]
+        let declineAutomaticChecks = app.windows.buttons["Don’t Check"].firstMatch
         if declineAutomaticChecks.waitForExistence(timeout: 2) {
             declineAutomaticChecks.click()
         }


### PR DESCRIPTION
## Summary
- dismiss Sparkle’s first-launch update-check consent dialog in UI test setup
- keep clean hosted runners focused on Dory’s own UI
- no production or release artifact changes

## Validation
- UI test target builds successfully with Xcode 26.6 RC
- installed Dory 0.4.4 remains healthy with Docker server 29.6.1
- GitHub Actions is the authoritative clean-runner UI verification