### PR TITLE
fix: complete Homebrew repair and release publication

### DIFF
--- a/.github/scripts/verify-public-release.py
+++ b/.github/scripts/verify-public-release.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Fail unless every public Dory release surface serves one exact candidate."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import os
+import pathlib
+import re
+import sys
+import time
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ET
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"public release verification: {message}")
+
+
+def fetch(url: str, *, token: str = "", attempts: int = 4, delay: int = 2) -> bytes:
+    separator = "&" if "?" in url else "?"
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "Dory-public-release-verifier",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    last_error: Exception | None = None
+    for attempt in range(1, attempts + 1):
+        request = urllib.request.Request(
+            f"{url}{separator}dory_verify={time.time_ns()}", headers=headers
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=60) as response:
+                return response.read()
+        except Exception as error:  # pragma: no cover - error details are surfaced below
+            last_error = error
+            if attempt < attempts:
+                time.sleep(delay)
+    fail(f"could not fetch {url}: {last_error}")
+
+
+def sha256(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def release_asset_bytes(asset: dict[str, object]) -> bytes:
+    url = str(asset.get("browser_download_url", ""))
+    if not url:
+        fail(f"release asset {asset.get('name')!r} has no download URL")
+    return fetch(url)
+
+
+def parse_cask(payload: bytes, label: str) -> tuple[str, str]:
+    text = payload.decode("utf-8")
+    version_match = re.search(r'^  version "([^"]+)"$', text, re.MULTILINE)
+    digest_match = re.search(r'^  sha256 "([0-9a-f]{64})"$', text, re.MULTILINE)
+    if not version_match or not digest_match:
+        fail(f"{label} does not contain one pinned version and SHA-256")
+    return version_match.group(1), digest_match.group(1)
+
+
+def verify_casks(version: str, digest: str) -> None:
+    urls = {
+        "Dory repository cask":
+            "https://raw.githubusercontent.com/Augani/dory/main/Casks/dory.rb",
+        "homebrew-dory tap cask":
+            "https://raw.githubusercontent.com/Augani/homebrew-dory/main/Casks/dory.rb",
+    }
+    pending = dict(urls)
+    errors: list[str] = []
+    for attempt in range(1, 19):
+        errors = []
+        for label, url in list(pending.items()):
+            try:
+                actual_version, actual_digest = parse_cask(fetch(url, attempts=1), label)
+                if (actual_version, actual_digest) != (version, digest):
+                    errors.append(
+                        f"{label} serves {actual_version}/{actual_digest}, expected {version}/{digest}"
+                    )
+                    continue
+                del pending[label]
+            except (Exception, SystemExit) as error:  # pragma: no cover - propagation retry
+                errors.append(str(error))
+        if not pending:
+            return
+        if attempt < 18:
+            time.sleep(5)
+    fail("; ".join(errors))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", default="Augani/dory")
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--source-commit", required=True)
+    parser.add_argument("--expected-primary-sha256", required=True)
+    arguments = parser.parse_args()
+
+    if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", arguments.version):
+        fail("version must be a stable semantic version such as 0.4.5")
+    if not re.fullmatch(r"[0-9a-f]{40}", arguments.source_commit):
+        fail("source commit must be a full lowercase Git SHA")
+    if not re.fullmatch(r"[0-9a-f]{64}", arguments.expected_primary_sha256):
+        fail("primary SHA-256 must contain 64 lowercase hexadecimal characters")
+
+    token = os.environ.get("GH_TOKEN", "")
+    tag = f"v{arguments.version}"
+    api_url = f"https://api.github.com/repos/{arguments.repository}/releases/tags/{tag}"
+    release = json.loads(fetch(api_url, token=token).decode("utf-8"))
+    if release.get("tag_name") != tag or release.get("draft") or release.get("prerelease"):
+        fail(f"{tag} is not a public stable release")
+
+    asset_rows = release.get("assets", [])
+    assets = {str(row["name"]): row for row in asset_rows}
+    if len(assets) != len(asset_rows):
+        fail("release contains duplicate asset names")
+
+    version = arguments.version
+    required = {
+        f"Dory-{version}-arm64.zip",
+        f"Dory-{version}.zip",
+        f"Dory-{version}-arm64.dmg",
+        f"Dory-{version}.dmg",
+        f"Dory-{version}-app-update.zip",
+        f"dory-engine-{version}-arm64.tar.gz",
+        f"Dory-{version}.cdx.json",
+        f"Dory-{version}-performance-evidence.zip",
+        f"Dory-{version}-reliability-evidence.zip",
+        f"Dory-{version}-reliability-evidence.zip.sha256",
+        "release-manifest.json",
+        "appcast.xml",
+        "catalog.json",
+        "catalog.json.sha256",
+        "catalog.json.sig",
+    }
+    missing = required - assets.keys()
+    if missing:
+        fail(f"required release assets are missing: {', '.join(sorted(missing))}")
+
+    manifest_bytes = release_asset_bytes(assets["release-manifest.json"])
+    manifest = json.loads(manifest_bytes.decode("utf-8"))
+    if manifest.get("schemaVersion") != 2:
+        fail("release manifest must use the complete schema version 2 contract")
+    if manifest.get("version") != version:
+        fail("release manifest version does not match the tag")
+    if manifest.get("sourceCommit") != arguments.source_commit:
+        fail("release manifest source commit does not match the workflow commit")
+    if manifest.get("publicRelease") is not True or manifest.get("notarized") is not True:
+        fail("release manifest is not a notarized public-release manifest")
+    if assets["release-manifest.json"].get("digest") != f"sha256:{sha256(manifest_bytes)}":
+        fail("GitHub digest does not match release-manifest.json")
+
+    manifest_artifacts = manifest.get("artifacts", [])
+    if not manifest_artifacts:
+        fail("release manifest has no artifacts")
+    for row in manifest_artifacts:
+        name = str(row.get("name", ""))
+        if name not in assets:
+            fail(f"manifest artifact is not published: {name}")
+        asset = assets[name]
+        expected_digest = f"sha256:{row.get('sha256', '')}"
+        if asset.get("digest") != expected_digest:
+            fail(f"GitHub digest does not match the manifest for {name}")
+        if asset.get("size") != row.get("bytes"):
+            fail(f"GitHub size does not match the manifest for {name}")
+
+    primary_name = f"Dory-{version}.zip"
+    primary = assets[primary_name]
+    if primary.get("digest") != f"sha256:{arguments.expected_primary_sha256}":
+        fail("primary ZIP digest differs from the qualified candidate")
+
+    appcast_bytes = release_asset_bytes(assets["appcast.xml"])
+    if assets["appcast.xml"].get("digest") != f"sha256:{sha256(appcast_bytes)}":
+        fail("GitHub digest does not match appcast.xml")
+    live_appcast = fetch("https://augani.github.io/dory/appcast.xml", attempts=8, delay=3)
+    if live_appcast != appcast_bytes:
+        fail("live Sparkle appcast differs from the release asset")
+    sparkle = "http://www.andymatuschak.org/xml-namespaces/sparkle"
+    item = ET.fromstring(appcast_bytes).find("./channel/item")
+    if item is None or item.findtext(f"{{{sparkle}}}shortVersionString") != version:
+        fail("live appcast does not advertise the released version")
+    enclosure = item.find("enclosure")
+    if enclosure is None:
+        fail("live appcast has no enclosure")
+    update_name = pathlib.PurePosixPath(
+        urllib.parse.urlparse(enclosure.attrib.get("url", "")).path
+    ).name
+    if update_name != f"Dory-{version}-app-update.zip":
+        fail(f"live appcast encloses the wrong asset: {update_name}")
+    if int(enclosure.attrib.get("length", "0")) != assets[update_name].get("size"):
+        fail("live appcast enclosure length differs from the update ZIP")
+    try:
+        signature = base64.b64decode(
+            enclosure.attrib[f"{{{sparkle}}}edSignature"], validate=True
+        )
+    except Exception as error:
+        fail(f"live appcast signature is not valid base64: {error}")
+    if len(signature) != 64:
+        fail("live appcast does not contain a 64-byte Ed25519 signature")
+
+    catalog_bytes = release_asset_bytes(assets["catalog.json"])
+    catalog_digest_bytes = release_asset_bytes(assets["catalog.json.sha256"])
+    catalog_signature_bytes = release_asset_bytes(assets["catalog.json.sig"])
+    for name, payload in {
+        "catalog.json": catalog_bytes,
+        "catalog.json.sha256": catalog_digest_bytes,
+        "catalog.json.sig": catalog_signature_bytes,
+    }.items():
+        if assets[name].get("digest") != f"sha256:{sha256(payload)}":
+            fail(f"GitHub digest does not match {name}")
+    expected_catalog_digest = sha256(catalog_bytes)
+    if catalog_digest_bytes.decode("utf-8").strip() != expected_catalog_digest:
+        fail("published component catalog digest does not match catalog.json")
+    try:
+        catalog_signature = base64.b64decode(catalog_signature_bytes.strip(), validate=True)
+    except Exception as error:
+        fail(f"component catalog signature is not valid base64: {error}")
+    if len(catalog_signature) != 64:
+        fail("component catalog does not contain a 64-byte Ed25519 signature")
+
+    live_component_root = "https://augani.github.io/dory/components/arm64"
+    for name, expected in {
+        "catalog.json": catalog_bytes,
+        "catalog.json.sha256": catalog_digest_bytes,
+        "catalog.json.sig": catalog_signature_bytes,
+    }.items():
+        if fetch(f"{live_component_root}/{name}", attempts=8, delay=3) != expected:
+            fail(f"live component metadata differs from the release asset: {name}")
+
+    catalog = json.loads(catalog_bytes.decode("utf-8"))
+    if catalog.get("releaseVersion") != version or catalog.get("architecture") != "arm64":
+        fail("component catalog release identity is invalid")
+    component_assets = [
+        row
+        for component in catalog.get("components", [])
+        for row in component.get("assets", [])
+    ]
+    if not component_assets:
+        fail("component catalog contains no downloadable assets")
+    for row in component_assets:
+        name = pathlib.PurePosixPath(urllib.parse.urlparse(row.get("url", "")).path).name
+        if name not in assets:
+            fail(f"catalog component is not a release asset: {name}")
+        if assets[name].get("digest") != f"sha256:{row.get('sha256', '')}":
+            fail(f"catalog digest differs from the GitHub asset for {name}")
+        if assets[name].get("size") != row.get("downloadBytes"):
+            fail(f"catalog size differs from the GitHub asset for {name}")
+
+    reliability_name = f"Dory-{version}-reliability-evidence.zip"
+    reliability_digest = release_asset_bytes(assets[f"{reliability_name}.sha256"])
+    reliability_fields = reliability_digest.decode("utf-8").strip().split()
+    if len(reliability_fields) != 2 or pathlib.PurePath(reliability_fields[1]).name != reliability_name:
+        fail("reliability evidence digest file is malformed")
+    if assets[reliability_name].get("digest") != f"sha256:{reliability_fields[0]}":
+        fail("reliability evidence ZIP differs from its published digest file")
+
+    verify_casks(version, arguments.expected_primary_sha256)
+    print(
+        f"public release verification: PASS ({tag}, {len(assets)} assets, "
+        f"{len(component_assets)} component downloads, Pages and both casks exact)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/verify-release-workflow-contract.py
+++ b/.github/scripts/verify-release-workflow-contract.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Static regression contract for the one-command public release path."""
+
+from pathlib import Path
+
+
+def require(text: str, value: str, message: str) -> None:
+    if value not in text:
+        raise SystemExit(f"release workflow contract: {message}")
+
+
+workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+publisher = Path("scripts/publish-release.sh").read_text(encoding="utf-8")
+
+candidate = workflow.split("      - name: Stage immutable public candidate", 1)[1].split(
+    "\n  homebrew_install_certification:", 1
+)[0]
+publication = workflow.split("  publish_release:", 1)[1].split("\n  publish-pages:", 1)[0]
+pages = workflow.split("  publish-pages:", 1)[1].split("\n  # Keeps the Homebrew", 1)[0]
+bump = workflow.split("  bump-cask:", 1)[1].split("\n  verify-public-release:", 1)[0]
+final = workflow.split("  verify-public-release:", 1)[1]
+
+require(candidate, "release-build/components/arm64/*", "candidate omits component payloads")
+require(publication, "release-build/components/arm64/*", "GitHub release omits component payloads")
+for name in ("catalog.json", "catalog.json.sha256", "catalog.json.sig"):
+    require(publication, f"release-build/components/arm64/{name}", f"metadata artifact omits {name}")
+    require(pages, f"component-catalog-artifact/{name}", f"Pages does not deploy {name}")
+    require(pages, f"live/components/arm64/{name}", f"Pages does not verify live {name}")
+
+require(bump, "needs: [publish_release, publish-pages]", "Homebrew can publish before assets/Pages")
+require(bump, "git add Casks/dory.rb", "in-repository Homebrew cask is not updated")
+require(bump, "git@github.com:Augani/homebrew-dory.git", "standalone Homebrew tap is not updated")
+require(bump, 'grep -qF "sha256 \\"$S\\"" <<< "$remote"', "standalone tap checksum is not verified")
+require(final, "needs: [publish_release, publish-pages, bump-cask]", "no terminal publication gate")
+require(final, ".github/scripts/verify-public-release.py", "terminal publication verifier is not run")
+
+require(publisher, 'gh workflow run "$WORKFLOW"', "publisher does not dispatch the release workflow")
+require(publisher, 'gh run watch "$RUN_ID"', "publisher does not wait for the complete workflow")
+require(publisher, ".github/scripts/verify-public-release.py", "publisher skips independent live verification")
+
+print("release workflow contract: PASS")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
 # Builds, signs, notarizes, and publishes a Dory release on manual dispatch.
+# Start public releases only through: scripts/publish-release.sh VERSION
 #
 # Required repository secrets:
 #   DEVELOPER_ID_CERT_P12_BASE64  base64 of your "Developer ID Application" .p12
@@ -682,6 +683,7 @@ jobs:
             release-build/*.cdx.json
             release-build/appcast.xml
             release-build/release-manifest.json
+            release-build/components/arm64/*
 
   homebrew_install_certification:
     name: Clean exact-candidate Homebrew install and uninstall
@@ -1527,6 +1529,15 @@ jobs:
           name: dory-appcast
           path: release-build/appcast.xml
           if-no-files-found: error
+      - name: Upload generated component catalog
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: dory-component-catalog
+          path: |
+            release-build/components/arm64/catalog.json
+            release-build/components/arm64/catalog.json.sha256
+            release-build/components/arm64/catalog.json.sig
+          if-no-files-found: error
 
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
@@ -1543,6 +1554,7 @@ jobs:
             release-build/Dory-${{ needs.release_candidate.outputs.version }}.cdx.json
             release-build/release-manifest.json
             release-build/appcast.xml
+            release-build/components/arm64/*
             performance-evidence/Dory-${{ needs.release_candidate.outputs.version }}-performance-evidence.zip
             ${{ runner.temp }}/Dory-${{ needs.release_candidate.outputs.version }}-reliability-evidence.zip
             ${{ runner.temp }}/Dory-${{ needs.release_candidate.outputs.version }}-reliability-evidence.zip.sha256
@@ -1621,14 +1633,24 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - name: Download the appcast generated from the signed update ZIP
+      - name: Download metadata generated from the signed release
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: dory-appcast
           path: appcast-artifact
+      - name: Download catalog generated from the signed release
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: dory-component-catalog
+          path: component-catalog-artifact
       - name: Validate generated live feed input
         run: |
           test -s appcast-artifact/appcast.xml
+          test -s component-catalog-artifact/catalog.json
+          test -s component-catalog-artifact/catalog.json.sha256
+          test -s component-catalog-artifact/catalog.json.sig
+          test "$(tr -d '[:space:]' < component-catalog-artifact/catalog.json.sha256)" = \
+            "$(sha256sum component-catalog-artifact/catalog.json | awk '{print $1}')"
           python3 - appcast-artifact/appcast.xml "${{ needs.publish_release.outputs.version }}" <<'PY'
           import os
           import sys
@@ -1660,30 +1682,48 @@ jobs:
         working-directory: website
       - run: npm run build
         working-directory: website
-      - name: Overlay the exact release appcast onto the complete site
+      - name: Overlay the exact release metadata onto the complete site
         run: |
           test -d docs-build
           cp appcast-artifact/appcast.xml docs-build/appcast.xml
           cmp appcast-artifact/appcast.xml docs-build/appcast.xml
+          mkdir -p docs-build/components/arm64
+          for name in catalog.json catalog.json.sha256 catalog.json.sig; do
+            cp "component-catalog-artifact/$name" "docs-build/components/arm64/$name"
+            cmp "component-catalog-artifact/$name" "docs-build/components/arm64/$name"
+          done
       - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
       - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: docs-build
       - id: deployment
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
-      - name: Verify the actual SUFeedURL serves this release
+      - name: Verify the public update metadata exactly matches this release
         run: |
-          expected='<sparkle:shortVersionString>${{ needs.publish_release.outputs.version }}</sparkle:shortVersionString>'
+          live="$RUNNER_TEMP/live-release-metadata"
+          rm -rf "$live"
+          mkdir -p "$live/components/arm64"
           for attempt in $(seq 1 18); do
-            if curl -fsSL --connect-timeout 10 --max-time 30 \
-              "https://augani.github.io/dory/appcast.xml?release=${{ needs.publish_release.outputs.version }}&run=${{ github.run_id }}" \
-              | grep -qF "$expected"; then
-              echo "Live Sparkle feed serves ${{ needs.publish_release.outputs.version }}"
+            complete=1
+            curl -fsSL --connect-timeout 10 --max-time 30 \
+              "https://augani.github.io/dory/appcast.xml?release=${{ needs.publish_release.outputs.version }}&run=${{ github.run_id }}&attempt=$attempt" \
+              -o "$live/appcast.xml" || complete=0
+            for name in catalog.json catalog.json.sha256 catalog.json.sig; do
+              curl -fsSL --connect-timeout 10 --max-time 30 \
+                "https://augani.github.io/dory/components/arm64/$name?release=${{ needs.publish_release.outputs.version }}&run=${{ github.run_id }}&attempt=$attempt" \
+                -o "$live/components/arm64/$name" || complete=0
+            done
+            if [ "$complete" = 1 ] \
+               && cmp appcast-artifact/appcast.xml "$live/appcast.xml" \
+               && cmp component-catalog-artifact/catalog.json "$live/components/arm64/catalog.json" \
+               && cmp component-catalog-artifact/catalog.json.sha256 "$live/components/arm64/catalog.json.sha256" \
+               && cmp component-catalog-artifact/catalog.json.sig "$live/components/arm64/catalog.json.sig"; then
+              echo "Public appcast and component catalog exactly match ${{ needs.publish_release.outputs.version }}"
               exit 0
             fi
             [ "$attempt" -eq 18 ] || sleep 5
           done
-          echo "Live SUFeedURL did not converge to ${{ needs.publish_release.outputs.version }}" >&2
+          echo "Public update metadata did not converge to ${{ needs.publish_release.outputs.version }}" >&2
           exit 1
 
   # Keeps the Homebrew cask in this repo (the tap) current after every release.
@@ -1768,3 +1808,22 @@ jobs:
           done
           echo "homebrew-dory did not converge to $V" >&2
           exit 1
+
+  verify-public-release:
+    name: Verify complete public distribution
+    needs: [publish_release, publish-pages, bump-cask]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Verify GitHub assets, Pages metadata, and both Homebrew casks
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python3 .github/scripts/verify-public-release.py \
+            --repository "$GITHUB_REPOSITORY" \
+            --version "${{ needs.publish_release.outputs.version }}" \
+            --source-commit "$GITHUB_SHA" \
+            --expected-primary-sha256 "${{ needs.publish_release.outputs.sha256 }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Release publication contract
+        run: scripts/publish-release.sh --check
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           components: rustfmt, clippy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,20 @@ scripts/build.sh
 scripts/test.sh
 ```
 
+## Publishing a release
+
+There is one supported public-release entrypoint:
+
+```sh
+scripts/publish-release.sh 0.4.5
+```
+
+Run it from a clean `main` branch after updating the project version. It dispatches and waits for
+the complete release workflow: build, signing, notarization, qualification, GitHub assets, Sparkle
+and component metadata on Pages, both Homebrew casks, and terminal live verification. A run is not
+successful until every public surface serves the same candidate. Do not manually upload or replace
+release assets; rerun the complete workflow instead.
+
 ## Reporting issues
 
 Open a GitHub issue with reproduction steps, expected and actual behavior, macOS version, Mac model,

--- a/Casks/dory.rb
+++ b/Casks/dory.rb
@@ -2,7 +2,7 @@
 # also syncs this file to the Augani/homebrew-dory tap.  Install:  brew install --cask Augani/dory/dory
 cask "dory" do
   version "0.4.4"
-  sha256 "ba9c476ad7c2e1e626d0b28a18096244b6f8e49b62b02fe3327f298583e6b60c"
+  sha256 "813c9c2c27707de34742ca8054201fa6bc70bd7eee5d79da5182eaf745299281"
 
   url "https://github.com/Augani/dory/releases/download/v#{version}/Dory-#{version}.zip"
   name "Dory"

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# The only supported entrypoint for publishing a public Dory release.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+REPOSITORY="Augani/dory"
+WORKFLOW="release.yml"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/publish-release.sh VERSION
+
+Dispatches the complete release workflow from an exact, clean main branch and waits until GitHub
+assets, Pages update metadata, the in-repository cask, and the Augani/homebrew-dory tap have all
+been published and independently verified.
+
+Example:
+  scripts/publish-release.sh 0.4.5
+EOF
+}
+
+die() {
+  echo "release publication error: $*" >&2
+  exit 1
+}
+
+if [ "${1:-}" = "--check" ]; then
+  [ "$#" -eq 1 ] || { usage >&2; exit 64; }
+  exec python3 .github/scripts/verify-release-workflow-contract.py
+fi
+
+[ "$#" -eq 1 ] || { usage >&2; exit 64; }
+VERSION="$1"
+printf '%s\n' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' \
+  || die "VERSION must be a stable semantic version such as 0.4.5"
+
+for command in git gh python3; do
+  command -v "$command" >/dev/null || die "$command is required"
+done
+gh auth status >/dev/null 2>&1 || die "authenticate first with: gh auth login"
+[ "$(gh repo view --json nameWithOwner --jq .nameWithOwner)" = "$REPOSITORY" ] \
+  || die "this checkout is not $REPOSITORY"
+
+python3 .github/scripts/verify-release-workflow-contract.py
+git fetch --quiet origin main
+[ "$(git branch --show-current)" = main ] || die "public releases must start from main"
+[ -z "$(git status --porcelain --untracked-files=normal)" ] \
+  || die "the working tree must be clean"
+HEAD_SHA="$(git rev-parse HEAD)"
+[ "$HEAD_SHA" = "$(git rev-parse origin/main)" ] \
+  || die "local main must exactly match origin/main"
+
+PROJECT_VERSIONS="$(sed -n -E 's/^[[:space:]]*MARKETING_VERSION = ([^;]+);/\1/p' \
+  Dory.xcodeproj/project.pbxproj | sort -u)"
+[ "$PROJECT_VERSIONS" = "$VERSION" ] \
+  || die "project MARKETING_VERSION is '${PROJECT_VERSIONS:-missing}', expected $VERSION"
+
+if git ls-remote --exit-code --tags origin "refs/tags/v$VERSION" >/dev/null 2>&1; then
+  die "tag v$VERSION already exists"
+fi
+if gh release view "v$VERSION" --repo "$REPOSITORY" >/dev/null 2>&1; then
+  die "release v$VERSION already exists"
+fi
+
+BEFORE_RUN="$(gh run list --repo "$REPOSITORY" --workflow "$WORKFLOW" \
+  --event workflow_dispatch --limit 1 --json databaseId --jq '.[0].databaseId // 0')"
+echo "Dispatching the complete Dory $VERSION release from $HEAD_SHA..."
+gh workflow run "$WORKFLOW" --repo "$REPOSITORY" --ref main --field "version=$VERSION"
+
+RUN_ID=""
+for attempt in $(seq 1 30); do
+  RUN_ID="$(gh run list --repo "$REPOSITORY" --workflow "$WORKFLOW" \
+    --event workflow_dispatch --branch main --limit 20 --json databaseId,headSha \
+    --jq "map(select(.databaseId > $BEFORE_RUN and .headSha == \"$HEAD_SHA\")) | sort_by(.databaseId) | last | .databaseId // empty")"
+  [ -n "$RUN_ID" ] && break
+  [ "$attempt" -eq 30 ] || sleep 2
+done
+[ -n "$RUN_ID" ] || die "could not resolve the newly dispatched workflow run"
+
+RUN_URL="https://github.com/$REPOSITORY/actions/runs/$RUN_ID"
+echo "Release workflow: $RUN_URL"
+gh run watch "$RUN_ID" --repo "$REPOSITORY" --exit-status
+
+PRIMARY_SHA256="$(gh api "repos/$REPOSITORY/releases/tags/v$VERSION" \
+  --jq ".assets[] | select(.name == \"Dory-$VERSION.zip\") | .digest" \
+  | sed 's/^sha256://')"
+[ -n "$PRIMARY_SHA256" ] || die "published primary ZIP has no GitHub SHA-256 digest"
+
+GH_TOKEN="$(gh auth token)" python3 .github/scripts/verify-public-release.py \
+  --repository "$REPOSITORY" \
+  --version "$VERSION" \
+  --source-commit "$HEAD_SHA" \
+  --expected-primary-sha256 "$PRIMARY_SHA256"
+
+echo "Dory $VERSION is completely published: https://github.com/$REPOSITORY/releases/tag/v$VERSION"


### PR DESCRIPTION
## Summary

- correct the v0.4.4 cask checksum to match the repaired public ZIP
- add `scripts/publish-release.sh VERSION` as the only supported public-release entrypoint
- include all component payloads and catalog files in the immutable candidate and GitHub release
- deploy both the Sparkle appcast and signed component catalog to Pages
- retain automated updates for the repository cask and `Augani/homebrew-dory`
- add a terminal verifier covering manifest asset digests/sizes, live update metadata, component downloads, and both casks
- add a CI contract preventing those publication stages from being removed

Closes #64.

## Verification

- `ruby -c Casks/dory.rb`
- `brew style Casks/dory.rb`
- `scripts/publish-release.sh --check`
- workflow YAML parse
- `scripts/test-release-outputs.sh`
- cask checksum matches `release-manifest.json` and the GitHub release asset digest