### PR TITLE
feat: add ORCAROUTER_API_KEY to host env allow-list presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Added
+
+- Added `ORCAROUTER_API_KEY` to the host environment allow-list presets, so agent sandboxes can
+  copy the key through to an [OrcaRouter](https://www.orcarouter.ai) gateway at creation time.
+
 ## 0.4.5 - 2026-08-13
 
 ### Fixed

--- a/Dory/Features/Settings/SettingsView.swift
+++ b/Dory/Features/Settings/SettingsView.swift
@@ -1291,7 +1291,7 @@ struct SettingsView: View {
                     .help("Save environment allow-list")
                     .accessibilityIdentifier("machine-env-save")
                 }
-                TextField("ANTHROPIC_API_KEY, GH_TOKEN", text: $machineEnvAllowListDraft, onCommit: commitMachineEnvAllowListDraft)
+                TextField("ANTHROPIC_API_KEY, ORCAROUTER_API_KEY", text: $machineEnvAllowListDraft, onCommit: commitMachineEnvAllowListDraft)
                     .textFieldStyle(.plain)
                     .font(.mono(12))
                     .foregroundStyle(p.text)

--- a/Dory/Runtime/Machines/MachineEnvImport.swift
+++ b/Dory/Runtime/Machines/MachineEnvImport.swift
@@ -2,7 +2,7 @@ import Foundation
 
 nonisolated enum MachineEnvImport {
     static let defaultNames: [String] = ["ANTHROPIC_API_KEY"]
-    static let optionalExtras: [String] = ["OPENAI_API_KEY", "GH_TOKEN", "HF_TOKEN"]
+    static let optionalExtras: [String] = ["OPENAI_API_KEY", "ORCAROUTER_API_KEY", "GH_TOKEN", "HF_TOKEN"]
 
     static func normalize(_ names: [String]) -> [String] {
         var seen = Set<String>()

--- a/DoryTests/MachineEnvImportTests.swift
+++ b/DoryTests/MachineEnvImportTests.swift
@@ -4,7 +4,7 @@ import Testing
 struct MachineEnvImportTests {
     @Test func defaultsContainAnthropicOnly() {
         #expect(MachineEnvImport.defaultNames == ["ANTHROPIC_API_KEY"])
-        #expect(MachineEnvImport.optionalExtras == ["OPENAI_API_KEY", "GH_TOKEN", "HF_TOKEN"])
+        #expect(MachineEnvImport.optionalExtras == ["OPENAI_API_KEY", "ORCAROUTER_API_KEY", "GH_TOKEN", "HF_TOKEN"])
     }
 
     @Test func normalizeUppercasesAndDedupes() {

--- a/README.md
+++ b/README.md
@@ -346,8 +346,8 @@ Headless machines retain the smaller Alpine, `root`, and `/bin/sh` contract.
 ### Machine secrets and host access
 
 New machines do not receive arbitrary host environment variables. Settings contains an allow-list.
-`ANTHROPIC_API_KEY` is the default entry, while `OPENAI_API_KEY`, `GH_TOKEN`, and `HF_TOKEN` are
-available presets. Only named, non-empty values are copied at creation time.
+`ANTHROPIC_API_KEY` is the default entry, while `OPENAI_API_KEY`, `ORCAROUTER_API_KEY`, `GH_TOKEN`,
+and `HF_TOKEN` are available presets. Only named, non-empty values are copied at creation time.
 
 Mac folders are also private by default. A persistent machine sees only mounts selected at creation,
 and an agent sandbox sees no host files unless an explicit mount is supplied.


### PR DESCRIPTION
### What

Add `ORCAROUTER_API_KEY` as a named preset in Dory's host environment allow-list, alongside the existing `OPENAI_API_KEY` preset. When creating a new machine, Dory copies named, non-empty variables from the Mac host into the machine; this lets agent sandboxes carry an [OrcaRouter](https://www.orcarouter.ai) key through at creation time without editing the allow-list manually.

### Why

Dory already ships named presets for the keys agent sandboxes commonly need (`OPENAI_API_KEY`, `GH_TOKEN`, `HF_TOKEN`). OrcaRouter is an OpenAI-compatible gateway that runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes. Adding it as a first-class preset means users can point Dory sandboxes at OrcaRouter with a single toggle, the same way they use the OpenAI preset today.

### Changes

- `Dory/Runtime/Machines/MachineEnvImport.swift`: register `ORCAROUTER_API_KEY` in `optionalExtras`.
- `Dory/Features/Settings/SettingsView.swift`: surface it in the allow-list field hint.
- `DoryTests/MachineEnvImportTests.swift`: update the preset-list assertion.
- `README.md` / `CHANGELOG.md`: document the new preset.

### Verification

- Updated unit test assertion for `MachineEnvImport.optionalExtras`.
- Live check: `POST https://api.orcarouter.ai/v1/chat/completions` with model `orcarouter/auto` returns HTTP 200.

Disclosure: I'm an engineer on the OrcaRouter team.
