### PR TITLE
fix: keep agent-core install script from joining fiif

### DIFF
--- a/dory-core-swift/Sources/DorydKit/MachineRecipeProvisioner.swift
+++ b/dory-core-swift/Sources/DorydKit/MachineRecipeProvisioner.swift
@@ -32,6 +32,8 @@ public enum MachineRecipeProvisioner {
     }
 
     private static func packageInstallScript(alpine: String, debian: String) -> String {
+        // Swift multiline strings drop the newline before the closing delimiter.
+        // A later `if` must start on a new line so ash does not see `fiif`.
         """
         if command -v apk >/dev/null 2>&1; then
           apk add --no-cache \(alpine)
@@ -44,7 +46,7 @@ public enum MachineRecipeProvisioner {
           echo "Dory recipes support Alpine apk and Debian apt guests" >&2
           exit 69
         fi
-        """
+        """ + "\n"
     }
 
     public static func recipe(id rawID: String) throws -> Recipe {

--- a/dory-core-swift/Tests/DorydKitTests/MachineRecipeProvisionerTests.swift
+++ b/dory-core-swift/Tests/DorydKitTests/MachineRecipeProvisionerTests.swift
@@ -32,6 +32,13 @@ final class MachineRecipeProvisionerTests: XCTestCase {
         }
     }
 
+    func testAgentCoreInstallScriptDoesNotJoinFiIntoTheFdShim() throws {
+        let script = try MachineRecipeProvisioner.recipe(id: "agent-core").installScript
+        XCTAssertFalse(script.contains("fiif"), script)
+        XCTAssertTrue(script.contains("fi\nif ! command -v fd"), script)
+        XCTAssertTrue(script.contains("exit 69\nfi\n"), script)
+    }
+
     func testRequiredProvisioningStageRejectsNonzeroExitWithStderr() {
         let result = DoryExecResult(
             exitCode: 17,


### PR DESCRIPTION
## Summary

`dory sandbox create` always installs the `agent-core` recipe in the guest.
The guest `/bin/sh` then stops with a syntax error.
The command does not make a usable sandbox.

The error is:

```text
dorydctl: machine recipe agent-core install failed with exit code 2: /bin/sh: syntax error: unexpected "then" (expecting "fi")
Sandbox tool setup for agent-core was interrupted; retrying once.
dorydctl: machine recipe agent-core install failed with exit code 2: /bin/sh: syntax error: unexpected "then" (expecting "fi")
```

This is a defect in Dory 0.4.5.

## Procedure

Do this procedure to show the defect.

1. Start the Dory engine.
2. Open a terminal on the Mac.
3. Go to a project directory.
4. Run this command:

```text
dory sandbox create mtn-gw --workspace .
```

## Actual result

The CLI starts a Linux machine.
The CLI then runs `dorydctl machine provision NAME --recipe agent-core`.
The guest `/bin/sh` rejects the install script.
The CLI tries the same script one more time.
The CLI then stops and deletes the machine.

The incident log records this sequence:

- `machine.create`
- `machine.start`
- `machine.exec` with `/bin/sh`
- `machine.provision_failed` (two times)
- `machine.stop`
- `machine.delete`

The two `provision_failed` events occur in about 0.1 s.
The script does not start `apk`.
The failure is a parse error.

## Expected result

The recipe must send a valid POSIX script to `/bin/sh -lc`.
The guest must install the `agent-core` packages.
The command must keep a named Agent-ready sandbox.

## Cause

`dory sandbox create` always adds `--agent-ready`.
The Agent-ready profile always adds the `agent-core` tool.
`sandbox_provision_profile_tool` in `Helpers/dory` then runs:

```text
dorydctl machine provision NAME --recipe agent-core
```

`MachineRecipeProvisioner` builds the install script from two strings.

String 1 is `packageInstallScript(alpine:debian:)`.
Swift multiline strings drop the newline before the closing delimiter.
That string ends with `fi` and no newline.

String 2 is the `fd` shim.
That string starts with `if` and no leading newline.

The runtime join is:

```text
fiif ! command -v fd >/dev/null 2>&1 && command -v fdfind >/dev/null 2>&1; then
```

`fiif` is not the keyword `fi`.
The first `if` stays open.
Ash then finds `then` and reports `unexpected "then" (expecting "fi")`.

The provisioner sends the script as:

```text
["/bin/sh", "-lc", installScript]
```

The C strings in Dory 0.4.5 `dorydctl` match this join.
The last fragment of the package script is `exit 69\nfi` with no trailing newline.
The `fd` fragment starts with `if ! command -v fd`.

## Change

`packageInstallScript` now adds an explicit `"\n"` after `fi`.
A later `if` then starts on a new line.

The new test `testAgentCoreInstallScriptDoesNotJoinFiIntoTheFdShim` checks three facts:

- the script does not contain `fiif`
- the script contains `fi\nif ! command -v fd`
- the script contains `exit 69\nfi\n`

## Workaround

Do not use `dory sandbox create`.
That command always enables Agent-ready mode.

Use a named sandbox without `--agent-ready`:

```text
dory sandbox run --keep --name mtn-gw --mount "$PWD:/workspace:rw" -- /bin/true
dory sandbox exec mtn-gw -- /bin/sh -lc 'uname -a; ls /workspace'
```

This VM does not get the `agent-core` toolkit.

## Validation

- `scripts/build.sh` passed.
- The Rust workspace tests passed.
- The gvproxy tests passed.
- Both Swift package test suites passed.
- The Dory app test suite passed: 889 tests in 110 suites, with 0 failures.

## Related issues

These issues are not this defect:

- https://github.com/Augani/dory/issues/79
- https://github.com/Augani/dory/issues/37

I found no open or closed issue for this `fiif` syntax error.
