### PR TITLE
Validate exact VM qualification device contracts

### DIFF
--- a/.github/scripts/test-release-candidate-workflow.py
+++ b/.github/scripts/test-release-candidate-workflow.py
@@ -47,6 +47,10 @@ class ReleaseCandidateWorkflowTests(unittest.TestCase):
 
     def test_candidate_builds_every_modular_guest_from_its_commit(self) -> None:
         source = WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn(
+            "sudo apt-get install -y binutils e2fsprogs file patchelf protobuf-compiler zstd",
+            source,
+        )
         self.assertIn("DORY_EXPERIMENTAL_GPU=0 guest/kernel/build.sh arm64", source)
         self.assertIn("DORY_EXPERIMENTAL_GPU=1 guest/kernel/build.sh arm64", source)
         self.assertIn("DORY_KERNEL_PROFILE=accelerated-desktop guest/kernel/build.sh arm64", source)

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - name: Install guest build prerequisites
-        run: sudo apt-get update && sudo apt-get install -y binutils e2fsprogs file patchelf zstd
+        run: sudo apt-get update && sudo apt-get install -y binutils e2fsprogs file patchelf protobuf-compiler zstd
       - name: Expose rust-lld for the static guest agent
         run: |
           set -euo pipefail

--- a/scripts/build-components.py
+++ b/scripts/build-components.py
@@ -516,6 +516,92 @@ def boolean_value(value: object, label: str) -> bool:
     return value
 
 
+def bounded_integer_value(
+    value: object,
+    label: str,
+    *,
+    minimum: int,
+    maximum: int,
+) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not minimum <= value <= maximum
+    ):
+        fail(f"{label} must be an integer from {minimum} through {maximum}")
+    return value
+
+
+def validate_network_interface(value: object, label: str) -> dict:
+    interface = exact_keys(
+        value,
+        {"id", "macAddress", "maximumTransmissionUnit"},
+        set(),
+        label,
+    )
+    if interface["id"] != "nic0":
+        fail(f"{label} id must be nic0")
+    mac = nonempty_string(interface["macAddress"], f"{label} MAC address", 17)
+    if re.fullmatch(r"[0-9a-f]{2}(?::[0-9a-f]{2}){5}", mac) is None:
+        fail(f"{label} MAC address must be canonical lowercase hexadecimal")
+    octets = bytes(int(part, 16) for part in mac.split(":"))
+    if (
+        octets[0] & 0x01
+        or not octets[0] & 0x02
+        or all(value == 0 for value in octets)
+        or all(value == 0xFF for value in octets)
+    ):
+        fail(f"{label} MAC address must be a locally administered unicast address")
+    bounded_integer_value(
+        interface["maximumTransmissionUnit"],
+        f"{label} MTU",
+        minimum=1_280,
+        maximum=9_000,
+    )
+    return interface
+
+
+def validate_display(value: object, label: str) -> dict:
+    display = exact_keys(
+        value,
+        {"widthPixels", "heightPixels", "backingScaleFactor", "guestUIScaleFactor"},
+        {"id"},
+        label,
+    )
+    identifier = display.get("id", "display-0")
+    if (
+        not isinstance(identifier, str)
+        or re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,62}", identifier) is None
+    ):
+        fail(f"{label} id is invalid")
+    for field in ("widthPixels", "heightPixels"):
+        bounded_integer_value(
+            display[field], f"{label} {field}", minimum=1, maximum=16_384
+        )
+    bounded_integer_value(
+        display["backingScaleFactor"],
+        f"{label} backing scale",
+        minimum=1,
+        maximum=4,
+    )
+    bounded_integer_value(
+        display["guestUIScaleFactor"],
+        f"{label} guest UI scale",
+        minimum=1,
+        maximum=2,
+    )
+    return display
+
+
+def validate_clipboard_policy(value: object, label: str) -> dict:
+    policy = exact_keys(value, {"text", "image", "files"}, set(), label)
+    directions = {"off", "host-to-guest", "guest-to-host", "bidirectional"}
+    for field in ("text", "image", "files"):
+        if policy[field] not in directions:
+            fail(f"{label} {field} direction is unsupported")
+    return policy
+
+
 def validate_qualification_record(value: object, index: int) -> dict:
     label = f"qualification record {index}"
     required = {
@@ -586,15 +672,61 @@ def validate_qualification_record(value: object, index: int) -> dict:
             "directorySharing", "clipboard", "clockSynchronization", "dynamicDisplay",
             "gracefulShutdown",
         },
-        set(),
+        {
+            "networkInterface", "display", "displays", "cameraInput", "clipboardPolicy",
+            "intelApplicationTranslation", "removableUSBHotplug",
+        },
         f"{label} devices",
     )
     if devices["networkAttachment"] not in {
         "disconnected", "shared-nat", "bridged", "isolated",
     }:
         fail(f"{label} network attachment is unsupported")
-    for key in set(devices) - {"networkAttachment"}:
+    for key in (
+        "audioInput", "audioOutput", "keyboard", "pointer", "directorySharing",
+        "clipboard", "clockSynchronization", "dynamicDisplay", "gracefulShutdown",
+    ):
         boolean_value(devices[key], f"{label} device {key}")
+    for key in ("cameraInput", "intelApplicationTranslation", "removableUSBHotplug"):
+        if key in devices:
+            boolean_value(devices[key], f"{label} device {key}")
+
+    if "networkInterface" not in devices:
+        fail(f"{label} devices omit the production network interface contract")
+    validate_network_interface(
+        devices["networkInterface"], f"{label} network interface"
+    )
+
+    if "display" in devices and "displays" in devices:
+        fail(f"{label} devices cannot contain both display and displays")
+    if "display" in devices:
+        display_values = [validate_display(devices["display"], f"{label} display")]
+    elif "displays" in devices:
+        raw_displays = devices["displays"]
+        if not isinstance(raw_displays, list) or not 1 <= len(raw_displays) <= 16:
+            fail(f"{label} displays must contain from 1 through 16 entries")
+        display_values = [
+            validate_display(display, f"{label} display {display_index}")
+            for display_index, display in enumerate(raw_displays)
+        ]
+    else:
+        display_values = []
+    display_ids = [display.get("id", "display-0") for display in display_values]
+    if len(set(display_ids)) != len(display_ids):
+        fail(f"{label} display identifiers must be unique")
+    if record["graphics"] != "none" and not display_values:
+        fail(f"{label} graphical qualification omits its exact display contract")
+
+    if "clipboardPolicy" not in devices:
+        fail(f"{label} devices omit the typed clipboard policy")
+    clipboard_policy = validate_clipboard_policy(
+        devices["clipboardPolicy"], f"{label} clipboard policy"
+    )
+    clipboard_enabled = any(
+        clipboard_policy[field] != "off" for field in ("text", "image", "files")
+    )
+    if devices["clipboard"] != clipboard_enabled:
+        fail(f"{label} clipboard boolean contradicts its typed policy")
 
     components = record["components"]
     if not isinstance(components, list) or not components:

--- a/scripts/test-build-components.sh
+++ b/scripts/test-build-components.sh
@@ -1033,12 +1033,29 @@ manifest = {
         "graphics": "hardware-accelerated-3d",
         "devices": {
             "networkAttachment": "shared-nat",
+            "networkInterface": {
+                "id": "nic0",
+                "macAddress": "02:00:00:00:00:01",
+                "maximumTransmissionUnit": 1500,
+            },
+            "display": {
+                "widthPixels": 1920,
+                "heightPixels": 1080,
+                "backingScaleFactor": 2,
+                "guestUIScaleFactor": 2,
+            },
             "audioInput": True,
             "audioOutput": True,
+            "cameraInput": True,
             "keyboard": True,
             "pointer": True,
             "directorySharing": True,
             "clipboard": True,
+            "clipboardPolicy": {
+                "text": "bidirectional",
+                "image": "bidirectional",
+                "files": "off",
+            },
             "clockSynchronization": True,
             "dynamicDisplay": True,
             "gracefulShutdown": True,
@@ -1073,6 +1090,18 @@ elif mutation == "wrong-media":
     manifest["records"][0]["immutableArtifactSHA256"] = "d" * 64
 elif mutation == "wrong-release":
     manifest["catalogReleaseVersion"] = "9.8.6"
+elif mutation == "missing-network-interface":
+    del manifest["records"][0]["devices"]["networkInterface"]
+elif mutation == "missing-display":
+    del manifest["records"][0]["devices"]["display"]
+elif mutation == "missing-clipboard-policy":
+    del manifest["records"][0]["devices"]["clipboardPolicy"]
+elif mutation == "contradictory-clipboard-policy":
+    manifest["records"][0]["devices"]["clipboardPolicy"] = {
+        "text": "off",
+        "image": "off",
+        "files": "off",
+    }
 elif mutation != "none":
     raise SystemExit(f"unknown qualification mutation: {mutation}")
 pathlib.Path(destination).write_text(
@@ -1329,7 +1358,9 @@ grep -Fq 'final component output cannot be a symbolic link' "$TMP/indirect-final
   || { echo "component packaging mutated the symlink target" >&2; exit 1; }
 
 # Authenticated evidence must bind this inventory, SBOM, runtime helper, and packaged media.
-for mutation in wrong-inventory wrong-helper wrong-media wrong-release; do
+for mutation in wrong-inventory wrong-helper wrong-media wrong-release \
+  missing-network-interface missing-display missing-clipboard-policy \
+  contradictory-clipboard-policy; do
   manifest="$TMP/$mutation.json"
   signature="$TMP/$mutation.json.sig"
   write_qualification "$manifest" "$mutation"
@@ -1349,6 +1380,17 @@ grep -Fq 'bundled media digest is not inventory-bound' "$TMP/wrong-media.out" \
   || { echo "component packaging rejected media mismatch for the wrong reason" >&2; exit 1; }
 grep -Fq 'release does not match' "$TMP/wrong-release.out" \
   || { echo "component packaging rejected release mismatch for the wrong reason" >&2; exit 1; }
+grep -Fq 'omit the production network interface contract' \
+  "$TMP/missing-network-interface.out" \
+  || { echo "component packaging rejected the missing NIC contract for the wrong reason" >&2; exit 1; }
+grep -Fq 'graphical qualification omits its exact display contract' \
+  "$TMP/missing-display.out" \
+  || { echo "component packaging rejected the missing display contract for the wrong reason" >&2; exit 1; }
+grep -Fq 'omit the typed clipboard policy' "$TMP/missing-clipboard-policy.out" \
+  || { echo "component packaging rejected the missing clipboard policy for the wrong reason" >&2; exit 1; }
+grep -Fq 'clipboard boolean contradicts its typed policy' \
+  "$TMP/contradictory-clipboard-policy.out" \
+  || { echo "component packaging rejected contradictory clipboard authority for the wrong reason" >&2; exit 1; }
 
 printf '{"bomFormat":"CycloneDX","specVersion":"1.6","components":[{"name":"changed"}]}\n' \
   > "$TMP/other.cdx.json"


### PR DESCRIPTION
## Summary
- validate the production NIC and display topology in schema-2 VM qualification records
- validate typed clipboard policy and its compatibility boolean coherently
- admit and type-check camera, Intel translation, and removable USB capability fields
- add negative release-finalization coverage for missing or contradictory device authority
- install the protobuf compiler required by the candidate guest-agent build

## Root causes closed
- schema-2 finalization rejected typed device fields the Swift runtime requires, so exact accelerated-desktop authority could not be represented
- the first 0.4.6 candidate failed before signing because its ARM guest builder did not install `protoc`

## Verification
- `python3 -m py_compile scripts/build-components.py`
- `bash -n scripts/test-build-components.sh`
- `scripts/test-build-components.sh`
- `python3 .github/scripts/test-release-candidate-workflow.py`
- release-candidate YAML parse
- `DEVELOPER_DIR=/Applications/Xcode-26.6.0-Release.Candidate.app/Contents/Developer swift test --no-parallel --filter DoryVirtualMachineQualificationManifestTests`
- `git diff --check`