### PR TITLE
Fix release guest verification toolchain

### DIFF
--- a/.github/scripts/test-release-candidate-workflow.py
+++ b/.github/scripts/test-release-candidate-workflow.py
@@ -48,7 +48,13 @@ class ReleaseCandidateWorkflowTests(unittest.TestCase):
     def test_candidate_builds_every_modular_guest_from_its_commit(self) -> None:
         source = WORKFLOW.read_text(encoding="utf-8")
         self.assertIn(
-            "sudo apt-get install -y binutils e2fsprogs file patchelf protobuf-compiler zstd",
+            "sudo apt-get install -y binutils-aarch64-linux-gnu e2fsprogs file patchelf protobuf-compiler zstd",
+            source,
+        )
+        self.assertIn("command -v protoc", source)
+        self.assertIn("command -v aarch64-linux-gnu-readelf", source)
+        self.assertIn(
+            "DORY_AARCH64_READELF: /usr/bin/aarch64-linux-gnu-readelf",
             source,
         )
         self.assertIn("DORY_EXPERIMENTAL_GPU=0 guest/kernel/build.sh arm64", source)

--- a/.github/scripts/verify-release-workflow-contract.py
+++ b/.github/scripts/verify-release-workflow-contract.py
@@ -128,6 +128,23 @@ for job in ("rust-workspace", "guest-assets-arm64", "prepublication-quality"):
         raise SystemExit(f"release workflow contract: missing job {job}")
     section = match.group(1)
     require(section, "release-metadata", f"{job} can start before release identity validation")
+guest_job = re.search(
+    r"(?ms)^  guest-assets-arm64:\n(.*?)(?=^  [A-Za-z0-9_-]+:\n|\Z)", workflow
+)
+if guest_job is None:
+    raise SystemExit("release workflow contract: missing guest-assets-arm64 job")
+for prerequisite in (
+    "binutils-aarch64-linux-gnu",
+    "protobuf-compiler",
+    "command -v protoc",
+    "command -v aarch64-linux-gnu-readelf",
+    "DORY_AARCH64_READELF: /usr/bin/aarch64-linux-gnu-readelf",
+):
+    require(
+        guest_job.group(1),
+        prerequisite,
+        f"guest build does not fail fast on required toolchain prerequisite {prerequisite}",
+    )
 require(workflow, 'scripts/release.sh "${{ inputs.version }}" "${{ inputs.build }}"', "release build does not use validated dispatch metadata")
 require(workflow, 'BUILD: ${{ inputs.build }}', "downstream evidence is not bound to the dispatch build")
 if "releases/latest/download/appcast.xml" in workflow:

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -60,7 +60,14 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - name: Install guest build prerequisites
-        run: sudo apt-get update && sudo apt-get install -y binutils e2fsprogs file patchelf protobuf-compiler zstd
+        run: sudo apt-get update && sudo apt-get install -y binutils-aarch64-linux-gnu e2fsprogs file patchelf protobuf-compiler zstd
+      - name: Prove guest verification prerequisites before the long build
+        run: |
+          set -euo pipefail
+          command -v protoc
+          command -v aarch64-linux-gnu-readelf
+          DORY_AARCH64_READELF="$(command -v aarch64-linux-gnu-readelf)" \
+            bash -n guest/mesa/verify-build.sh
       - name: Expose rust-lld for the static guest agent
         run: |
           set -euo pipefail
@@ -79,6 +86,8 @@ jobs:
           DORY_EXPERIMENTAL_GPU=1 guest/kernel/verify-build.sh arm64
           guest/initfs/verify-build.sh arm64
       - name: Build and verify every optional desktop payload
+        env:
+          DORY_AARCH64_READELF: /usr/bin/aarch64-linux-gnu-readelf
         run: |
           set -euo pipefail
           DORY_KERNEL_PROFILE=accelerated-desktop guest/kernel/build.sh arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -321,7 +321,14 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - name: Install guest build prerequisites
-        run: sudo apt-get update && sudo apt-get install -y binutils e2fsprogs file patchelf zstd
+        run: sudo apt-get update && sudo apt-get install -y binutils-aarch64-linux-gnu e2fsprogs file patchelf protobuf-compiler zstd
+      - name: Prove guest verification prerequisites before the long build
+        run: |
+          set -euo pipefail
+          command -v protoc
+          command -v aarch64-linux-gnu-readelf
+          DORY_AARCH64_READELF="$(command -v aarch64-linux-gnu-readelf)" \
+            bash -n guest/mesa/verify-build.sh
       - name: Expose rust-lld for the static Linux guest agent
         run: |
           rust_lld="$(find "$(rustc --print sysroot)/lib/rustlib" -type f -name rust-lld | head -1)"
@@ -338,6 +345,8 @@ jobs:
           DORY_EXPERIMENTAL_GPU=1 guest/kernel/verify-build.sh arm64
           guest/initfs/verify-build.sh arm64
       - name: Build and verify every Linux desktop payload from this commit
+        env:
+          DORY_AARCH64_READELF: /usr/bin/aarch64-linux-gnu-readelf
         run: |
           DORY_KERNEL_PROFILE=accelerated-desktop guest/kernel/build.sh arm64
           for distro in debian ubuntu kali; do

--- a/guest/mesa/verify-build.sh
+++ b/guest/mesa/verify-build.sh
@@ -41,8 +41,17 @@ stamp_value() { sed -n "s/^$1=//p" "$STAMP"; }
 
 ZSTD="${DORY_ZSTD:-$(command -v zstd 2>/dev/null || true)}"
 [ -n "$ZSTD" ] || fail "zstd is required"
-READELF="${DORY_AARCH64_READELF:-$(command -v aarch64-elf-readelf 2>/dev/null || true)}"
-[ -n "$READELF" ] || fail "aarch64-elf-readelf is required for exact ELF verification"
+READELF="${DORY_AARCH64_READELF:-}"
+if [ -z "$READELF" ]; then
+  for candidate in aarch64-elf-readelf aarch64-linux-gnu-readelf; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      READELF="$(command -v "$candidate")"
+      break
+    fi
+  done
+fi
+[ -n "$READELF" ] || fail "an AArch64 GNU readelf is required for exact ELF verification"
+[ -x "$READELF" ] || fail "AArch64 GNU readelf is not executable: $READELF"
 "$ZSTD" -q -t "$RUNTIME" || fail "runtime archive is corrupt"
 
 EXTRACT="$(mktemp -d "${TMPDIR:-/tmp}/dory-mesa-verify.XXXXXX")"


### PR DESCRIPTION
## Root cause

The arm64 release runner built the Mesa/Venus payload successfully, then failed because the verifier only recognized the Homebrew-style `aarch64-elf-readelf` command. Ubuntu provides the GNU triplet as `aarch64-linux-gnu-readelf`, and the workflow did not install or preflight that tool. The public release workflow also still omitted `protoc`.

## Fix

- install the explicit AArch64 binutils and protobuf compiler in both candidate and public release workflows
- fail fast on both tools before the long guest build
- pass the exact readelf path into the desktop build
- support both Homebrew and GNU/Linux AArch64 readelf command names in the verifier
- add candidate and public workflow regression contracts

## Verification

- candidate workflow contract tests pass
- public release workflow contract passes
- both workflow files parse as YAML
- verifier syntax and `git diff --check` pass