### PR TITLE
Fix desktop NetworkManager profile permissions

### DIFF
--- a/.github/scripts/test-release-candidate-workflow.py
+++ b/.github/scripts/test-release-candidate-workflow.py
@@ -11,6 +11,7 @@ import unittest
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 WORKFLOW = ROOT / ".github" / "workflows" / "release-candidate.yml"
 RELEASE = ROOT / "scripts" / "release.sh"
+DESKTOP_BUILD = ROOT / "guest" / "desktop" / "build.sh"
 
 
 class ReleaseCandidateWorkflowTests(unittest.TestCase):
@@ -70,6 +71,18 @@ class ReleaseCandidateWorkflowTests(unittest.TestCase):
             )
         self.assertIn('guest/desktop/build.sh arm64 "$distro"', source)
         self.assertIn('guest/desktop/verify-build.sh arm64 "$distro"', source)
+
+    def test_desktop_builder_makes_the_network_profile_private(self) -> None:
+        source = DESKTOP_BUILD.read_text(encoding="utf-8")
+        overlay_copy = "cp -a --no-preserve=ownership /tmp/rootfs-overlay/. /rootfs/"
+        private_profile = (
+            "chmod 0600 \\\n"
+            "      /rootfs/etc/NetworkManager/system-connections/dory-wired.nmconnection"
+        )
+        self.assertIn(overlay_copy, source)
+        self.assertIn(private_profile, source)
+        self.assertLess(source.index(overlay_copy), source.index(private_profile))
+        self.assertLess(source.index(private_profile), source.index("mke2fs -q"))
 
     def test_release_script_keeps_publication_blocked_after_staging(self) -> None:
         subprocess.run(["bash", "-n", str(RELEASE)], cwd=ROOT, check=True)

--- a/guest/desktop/build.sh
+++ b/guest/desktop/build.sh
@@ -149,6 +149,11 @@ CID="$(docker_cmd create --privileged --platform linux/arm64 \
       "$DORY_DESKTOP_SUITE" /rootfs "$DORY_DESKTOP_MIRROR"
 
     cp -a --no-preserve=ownership /tmp/rootfs-overlay/. /rootfs/
+    # Git records only the executable bit, so a tracked NetworkManager profile arrives as 0644.
+    # NetworkManager requires system connection profiles to be root-private, and the image must
+    # establish that boundary before mke2fs captures the tree.
+    chmod 0600 \
+      /rootfs/etc/NetworkManager/system-connections/dory-wired.nmconnection
     /tmp/install-graphics-pack.sh /tmp/dory-mesa-venus-arm64.tar.zst /rootfs 0
     install -m0755 /tmp/dory-agent /rootfs/usr/bin/dory-agent
     chmod 0755 /rootfs/usr/lib/dory/clipboard /rootfs/usr/lib/dory/configure-machine /rootfs/usr/lib/dory/first-boot \


### PR DESCRIPTION
## Root cause

The exact Debian desktop image was assembled successfully, then the image verifier rejected `/etc/NetworkManager/system-connections/dory-wired.nmconnection` because it was mode `0644`. Git cannot encode owner-only `0600` for a normal tracked file, and the builder copied the overlay without re-establishing NetworkManager's private system-profile boundary.

## Fix

- set the system connection profile to `0600` immediately after copying the rootfs overlay and before filesystem creation
- add a release-candidate regression contract that proves the permission step exists in the correct ordering

## Verification

- desktop builder shell syntax passes
- release-candidate contract suite passes (4 tests)
- `git diff --check` passes
- the previous candidate advanced through the repaired AArch64 ELF verifier, built the Debian filesystem, and failed specifically at this mode assertion