### PR TITLE
Verify current Sparkle item without rejecting feed history

### DIFF
--- a/scripts/test-verify-sparkle-update.sh
+++ b/scripts/test-verify-sparkle-update.sh
@@ -20,16 +20,29 @@ write_plist() {
   cat > "$APP/Contents/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0"><dict><key>SUPublicEDKey</key><string>$key</string></dict></plist>
+<plist version="1.0"><dict>
+<key>SUPublicEDKey</key><string>$key</string>
+<key>CFBundleShortVersionString</key><string>0.3.0</string>
+<key>CFBundleVersion</key><string>12</string>
+</dict></plist>
 PLIST
 }
 
 cat > "$APPCAST" <<'XML'
 <?xml version="1.0"?>
 <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
-<channel><item><enclosure url="https://github.com/Augani/dory/releases/download/v0.3.0/Dory-0.3.0-app-update.zip"
+<channel>
+<item><title>0.3.0</title><sparkle:version>12</sparkle:version>
+<sparkle:shortVersionString>0.3.0</sparkle:shortVersionString>
+<enclosure url="https://github.com/Augani/dory/releases/download/v0.3.0/Dory-0.3.0-app-update.zip"
 sparkle:edSignature="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
-length="15" /></item></channel></rss>
+length="15" /></item>
+<item><title>0.2.9</title><sparkle:version>11</sparkle:version>
+<sparkle:shortVersionString>0.2.9</sparkle:shortVersionString>
+<enclosure url="https://github.com/Augani/dory/releases/download/v0.2.9/Dory-0.2.9-app-update.zip"
+sparkle:edSignature="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+length="14" /></item>
+</channel></rss>
 XML
 
 sed -i '' \
@@ -76,6 +89,43 @@ if EXPECTED_ZIP="$ZIP" EXPECTED_PRIVATE_KEY="$PRIVATE_KEY" \
   DORY_SPARKLE_SIGN_UPDATE="$TMP/sign_update" DORY_SPARKLE_PRIVATE_KEY="$PRIVATE_KEY" \
   scripts/verify-sparkle-update.sh "$APP" "$ZIP" "$TMP/wrong-appcast.xml" >/dev/null 2>&1; then
   echo "test-verify-sparkle-update: accepted an appcast pointing at another artifact" >&2
+  exit 1
+fi
+
+python3 - "$APPCAST" "$TMP/duplicate-current-appcast.xml" <<'PY'
+import pathlib
+import sys
+
+source = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+current = source[source.index("<item><title>0.3.0"):source.index("<item><title>0.2.9")]
+pathlib.Path(sys.argv[2]).write_text(
+    source.replace("<item><title>0.2.9", current + "<item><title>0.2.9", 1),
+    encoding="utf-8",
+)
+PY
+if scripts/verify-sparkle-update.sh "$APP" "$ZIP" "$TMP/duplicate-current-appcast.xml" \
+    >/dev/null 2>&1; then
+  echo "test-verify-sparkle-update: accepted duplicate current release items" >&2
+  exit 1
+fi
+
+python3 - "$APPCAST" "$TMP/wrong-build-appcast.xml" <<'PY'
+import pathlib
+import sys
+
+source = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+pathlib.Path(sys.argv[2]).write_text(
+    source.replace(
+        "<sparkle:version>12</sparkle:version>",
+        "<sparkle:version>13</sparkle:version>",
+        1,
+    ),
+    encoding="utf-8",
+)
+PY
+if scripts/verify-sparkle-update.sh "$APP" "$ZIP" "$TMP/wrong-build-appcast.xml" \
+    >/dev/null 2>&1; then
+  echo "test-verify-sparkle-update: accepted the wrong current build" >&2
   exit 1
 fi
 

--- a/scripts/verify-sparkle-update.sh
+++ b/scripts/verify-sparkle-update.sh
@@ -46,9 +46,15 @@ find_sign_update() {
   || fail "update ZIP is missing, indirect, or empty: $UPDATE_ZIP"
 [ -f "$APPCAST" ] && [ ! -L "$APPCAST" ] && [ -s "$APPCAST" ] \
   || fail "appcast is missing, indirect, or empty: $APPCAST"
+APP_VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' \
+  "$APP/Contents/Info.plist" 2>/dev/null || true)"
+APP_BUILD="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' \
+  "$APP/Contents/Info.plist" 2>/dev/null || true)"
+[ -n "$APP_VERSION" ] && [ -n "$APP_BUILD" ] \
+  || fail "candidate app has no release version/build identity"
 
 SIGNATURE="$(python3 - "$APPCAST" "$(basename "$UPDATE_ZIP")" \
-  "$(stat -f %z "$UPDATE_ZIP")" <<'PY'
+  "$(stat -f %z "$UPDATE_ZIP")" "$APP_VERSION" "$APP_BUILD" <<'PY'
 import base64
 import os
 import re
@@ -56,23 +62,40 @@ import sys
 import urllib.parse
 import xml.etree.ElementTree as ET
 
-path, expected_name, expected_length = sys.argv[1:4]
+path, expected_name, expected_length, expected_version, expected_build = sys.argv[1:6]
 sparkle = "http://www.andymatuschak.org/xml-namespaces/sparkle"
 items = ET.parse(path).getroot().findall("./channel/item")
-if len(items) != 1:
-    raise SystemExit("appcast must contain exactly one current item")
-item = items[0]
-enclosure = item.find("enclosure")
-if enclosure is None:
-    raise SystemExit("current appcast item has no enclosure")
-parsed = urllib.parse.urlparse(enclosure.attrib.get("url", ""))
-name = os.path.basename(parsed.path)
-if name != expected_name:
-    raise SystemExit(f"appcast encloses {name!r}, expected {expected_name!r}")
 match = re.fullmatch(r"Dory-(.+)-app-update\.zip", expected_name)
 if match is None:
     raise SystemExit("update ZIP name does not identify a Dory release")
-expected_path = f"/Augani/dory/releases/download/v{match.group(1)}/{expected_name}"
+release_version = match.group(1)
+if release_version != expected_version:
+    raise SystemExit("update ZIP version does not match the candidate app")
+expected_path = f"/Augani/dory/releases/download/v{release_version}/{expected_name}"
+current = []
+for item in items:
+    enclosure = item.find("enclosure")
+    parsed = urllib.parse.urlparse(enclosure.attrib.get("url", "")) if enclosure is not None else None
+    title = (item.findtext("title") or "").strip()
+    short_version = (item.findtext(f"{{{sparkle}}}shortVersionString") or "").strip()
+    path_matches_release = parsed is not None and parsed.path.startswith(
+        f"/Augani/dory/releases/download/v{release_version}/"
+    )
+    if title == release_version or short_version == release_version or path_matches_release:
+        current.append((item, enclosure, parsed))
+if len(current) != 1:
+    raise SystemExit("appcast must contain exactly one item for the current release")
+item, enclosure, parsed = current[0]
+if enclosure is None or parsed is None:
+    raise SystemExit("current appcast item has no enclosure")
+title = (item.findtext("title") or "").strip()
+short_version = (item.findtext(f"{{{sparkle}}}shortVersionString") or "").strip()
+build = (item.findtext(f"{{{sparkle}}}version") or "").strip()
+if title != release_version or short_version != release_version or build != expected_build:
+    raise SystemExit("current appcast item version/build does not match the candidate app")
+name = os.path.basename(parsed.path)
+if name != expected_name:
+    raise SystemExit(f"appcast encloses {name!r}, expected {expected_name!r}")
 if (
     parsed.scheme != "https"
     or parsed.netloc != "github.com"


### PR DESCRIPTION
## Summary
- select and verify the one appcast item bound to the current release while retaining historical items
- bind the current item title, short version, build, canonical release path, artifact length, and Ed25519 signature to the exact candidate app/update
- reject missing or duplicate current-release identities and mismatched app/update versions
- add historical-feed, duplicate-current, and wrong-build regression cases

## Root cause
The release generator correctly retains prior appcast entries, but `verify-sparkle-update.sh` required the entire feed to contain exactly one item. Every real feed with update history therefore failed after a successful local build.

## Verification
- `bash -n scripts/verify-sparkle-update.sh scripts/test-verify-sparkle-update.sh`
- `scripts/test-verify-sparkle-update.sh`
- `scripts/verify-sparkle-update.sh release-build/export-arm64/Dory.app release-build/Dory-0.4.6-app-update.zip release-build/appcast.xml`