### PR TITLE
Fix doryd execution admission in signed releases

### DIFF
--- a/.github/scripts/test-release-candidate-live-smoke.py
+++ b/.github/scripts/test-release-candidate-live-smoke.py
@@ -26,6 +26,7 @@ class ReleaseCandidateLiveSmokeTests(unittest.TestCase):
             "live qualification requires an exact source commit",
             "candidate app is unavailable or indirect",
             "candidate executable is unavailable or indirect",
+            'HV_RUNNER_EXECUTABLE="$APP/Contents/Helpers/DoryHVRunner.app/Contents/MacOS/dory-hv"',
             "candidate Docker socket is not owned by the release user",
             "candidate app has no valid notarization ticket",
             "candidate is not accepted as Notarized Developer ID",
@@ -72,7 +73,13 @@ class ReleaseCandidateLiveSmokeTests(unittest.TestCase):
             "DORY_RELEASE_LIVE_LOG_ROOT",
         ):
             self.assertIn(proof, text, proof)
-        for stale in ("alpine:latest", "nginx:alpine", "node:20-alpine", "assert "):
+        for stale in (
+            "alpine:latest",
+            "nginx:alpine",
+            "node:20-alpine",
+            "assert ",
+            '"$APP/Contents/Helpers/dory-hv"',
+        ):
             self.assertNotIn(stale, text, stale)
 
     def test_every_invoked_script_is_tracked(self) -> None:

--- a/.github/scripts/test-renderer-release-identity.py
+++ b/.github/scripts/test-renderer-release-identity.py
@@ -20,6 +20,7 @@ HELPER = ROOT / "scripts" / "renderer-release-identity.py"
 BUNDLE_ENGINE = ROOT / "scripts" / "bundle-engine.sh"
 RELEASE = ROOT / "scripts" / "release.sh"
 RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
+PACKAGE = ROOT / "dory-core-swift" / "Package.swift"
 
 
 def load_helper():
@@ -59,34 +60,32 @@ def production_details(
 
 
 class RendererReleaseIdentityTests(unittest.TestCase):
-    def test_canonical_entitlement_has_exact_shape_and_types(self) -> None:
-        expected = identity.release_identity_entitlements(
+    def test_canonical_embedded_identity_has_exact_shape_and_types(self) -> None:
+        expected = identity.release_identity_payload(
             runner_cdhash="a1" * 20,
             worker_cdhash="ab" * 20,
             tuple_digest="cd" * 32,
         )
-        self.assertEqual(set(expected), {identity.ENTITLEMENT_NAME})
-        nested = expected[identity.ENTITLEMENT_NAME]
-        self.assertEqual(set(nested), identity.IDENTITY_KEYS)
-        self.assertIs(type(nested["schema-version"]), int)
+        self.assertEqual(set(expected), identity.IDENTITY_KEYS)
+        self.assertIs(type(expected["schema-version"]), int)
         for field in (
             "runner-cdhash",
             "renderer-worker-cdhash",
             "tuple-definition-sha256",
         ):
-            self.assertIs(type(nested[field]), str)
+            self.assertIs(type(expected[field]), str)
 
-        raw = identity.canonical_entitlement_bytes(expected)
-        self.assertEqual(raw, identity.canonical_entitlement_bytes(expected))
+        raw = identity.canonical_identity_bytes(expected)
+        self.assertEqual(raw, identity.canonical_identity_bytes(expected))
         self.assertEqual(plistlib.loads(raw), expected)
         with tempfile.TemporaryDirectory() as temporary:
-            output = pathlib.Path(temporary) / "doryd.entitlements"
-            identity.write_entitlements(output, expected)
+            output = pathlib.Path(temporary) / "doryd-release-identity.plist"
+            identity.write_identity_plist(output, expected)
             self.assertEqual(output.read_bytes(), raw)
             self.assertEqual(output.stat().st_mode & 0o777, 0o600)
 
-    def test_entitlement_rejects_extra_missing_and_mistyped_fields(self) -> None:
-        expected = identity.release_identity_entitlements(
+    def test_embedded_identity_rejects_extra_missing_and_mistyped_fields(self) -> None:
+        expected = identity.release_identity_payload(
             runner_cdhash="a1" * 20,
             worker_cdhash="ab" * 20,
             tuple_digest="cd" * 32,
@@ -97,27 +96,23 @@ class RendererReleaseIdentityTests(unittest.TestCase):
         extra_top["unreviewed"] = True
         fixtures.append(extra_top)
 
-        extra_nested = copy.deepcopy(expected)
-        extra_nested[identity.ENTITLEMENT_NAME]["unreviewed"] = "value"
-        fixtures.append(extra_nested)
-
         missing = copy.deepcopy(expected)
-        del missing[identity.ENTITLEMENT_NAME]["runner-cdhash"]
+        del missing["runner-cdhash"]
         fixtures.append(missing)
 
         for wrong in (True, 1.0, "1"):
             mistyped = copy.deepcopy(expected)
-            mistyped[identity.ENTITLEMENT_NAME]["schema-version"] = wrong
+            mistyped["schema-version"] = wrong
             fixtures.append(mistyped)
 
         mistyped_hash = copy.deepcopy(expected)
-        mistyped_hash[identity.ENTITLEMENT_NAME]["runner-cdhash"] = b"a1" * 20
+        mistyped_hash["runner-cdhash"] = b"a1" * 20
         fixtures.append(mistyped_hash)
 
         for fixture in fixtures:
             with self.subTest(fixture=fixture):
                 with self.assertRaises(identity.ReleaseIdentityError):
-                    identity.validate_release_identity_entitlements(fixture, expected)
+                    identity.validate_release_identity_payload(fixture, expected)
 
     def test_signature_parser_requires_exact_production_identity(self) -> None:
         cdhash = identity.parse_production_signature_details(
@@ -194,6 +189,7 @@ class RendererReleaseIdentityTests(unittest.TestCase):
         bundle = BUNDLE_ENGINE.read_text(encoding="utf-8")
         release = RELEASE.read_text(encoding="utf-8")
         workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        package = PACKAGE.read_text(encoding="utf-8")
         execution = bundle.split("\nbundle_doryd_helpers\n", 1)[1]
         self.assertLess(
             execution.index("bundle_venus_renderer"),
@@ -213,13 +209,16 @@ class RendererReleaseIdentityTests(unittest.TestCase):
         )
         self.assertIn("verify-absent", bundle)
         self.assertIn("RawHV hardware 3D fails closed", bundle)
-        production_signer = bundle.split(
-            "codesign_production_release_identity() {", 1
-        )[1].split("\nfinalize_doryd_signature()", 1)[0]
-        self.assertIn("/usr/bin/codesign", production_signer)
-        self.assertIn("--identifier doryd", production_signer)
-        self.assertNotIn("DORY_ALLOW_ADHOC_SIGN", production_signer)
-        self.assertNotIn("--sign -", production_signer)
+        finalizer = bundle.split("finalize_doryd_signature() {", 1)[1].split(
+            "\nfind_debugfs()", 1
+        )[0]
+        self.assertIn("create-plist", finalizer)
+        self.assertIn("DORY_RENDERER_RELEASE_IDENTITY_PLIST", finalizer)
+        self.assertIn("sign_runtime_payload", finalizer)
+        self.assertNotIn("--entitlements", finalizer)
+        self.assertIn('"-Xlinker", "-sectcreate"', package)
+        self.assertIn('"-Xlinker", "__TEXT"', package)
+        self.assertIn('"-Xlinker", "__doryid"', package)
         self.assertIn("renderer-release-identity.py\" verify", release)
         self.assertIn(
             "public releases require the production doryd renderer release identity",
@@ -240,11 +239,11 @@ class RendererReleaseIdentityTests(unittest.TestCase):
             [
                 sys.executable,
                 str(HELPER),
-                "create-entitlements",
+                "create-plist",
                 "--runner-app",
                 "/nonexistent/DoryHVRunner.app",
                 "--output",
-                "/nonexistent/doryd.entitlements",
+                "/nonexistent/doryd-release-identity.plist",
                 "--expected-team",
                 "ABCDEFGHIJ",
             ],
@@ -270,27 +269,39 @@ class RendererReleaseIdentityTests(unittest.TestCase):
             identity.verify_absent(argparse.Namespace(doryd=doryd))
 
     @unittest.skipUnless(sys.platform == "darwin", "codesign fixture requires macOS")
-    def test_codesign_preserves_exact_custom_entitlement_shape(self) -> None:
-        expected = identity.release_identity_entitlements(
+    def test_codesign_seals_exact_embedded_identity_without_entitlements(self) -> None:
+        expected = identity.release_identity_payload(
             runner_cdhash="a1" * 20,
             worker_cdhash="ab" * 20,
             tuple_digest="cd" * 32,
         )
         with tempfile.TemporaryDirectory() as temporary:
             root = pathlib.Path(temporary)
+            source = root / "main.c"
+            source.write_text("int main(void) { return 0; }\n", encoding="utf-8")
             doryd = root / "doryd"
-            entitlements = root / "doryd.entitlements"
-            shutil.copyfile("/usr/bin/true", doryd)
-            doryd.chmod(0o755)
-            identity.write_entitlements(entitlements, expected)
+            embedded = root / "doryd-release-identity.plist"
+            identity.write_identity_plist(embedded, expected)
+            subprocess.run(
+                [
+                    "/usr/bin/clang",
+                    "-arch",
+                    "arm64",
+                    str(source),
+                    "-Wl,-sectcreate,__TEXT,__doryid," + str(embedded),
+                    "-o",
+                    str(doryd),
+                ],
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
             subprocess.run(
                 [
                     "/usr/bin/codesign",
                     "--force",
                     "--options",
                     "runtime",
-                    "--entitlements",
-                    str(entitlements),
                     "--sign",
                     "-",
                     str(doryd),
@@ -299,8 +310,15 @@ class RendererReleaseIdentityTests(unittest.TestCase):
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
             )
-            actual = identity.read_signed_entitlements(doryd, "fixture doryd")
-            identity.validate_release_identity_entitlements(actual, expected)
+            actual = identity.read_embedded_identity(doryd)
+            self.assertIsNotNone(actual)
+            identity.validate_release_identity_payload(actual, expected)
+            self.assertEqual(
+                identity.read_signed_entitlements(
+                    doryd, "fixture doryd", allow_empty=True
+                ),
+                {},
+            )
             with self.assertRaises(identity.ReleaseIdentityError):
                 identity.verify_absent(argparse.Namespace(doryd=doryd))
 

--- a/dory-core-swift/Package.swift
+++ b/dory-core-swift/Package.swift
@@ -5,6 +5,29 @@ import PackageDescription
 let packageRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
 let doryVMMInfoPlist = packageRoot.appendingPathComponent("Sources/dory-vmm/Info.plist").path
 
+let dorydRendererReleaseIdentityLinkerSettings: [LinkerSetting]
+if let rawIdentityPath = ProcessInfo.processInfo.environment[
+    "DORY_RENDERER_RELEASE_IDENTITY_PLIST"
+] {
+    guard rawIdentityPath.hasPrefix("/") else {
+        fatalError("DORY_RENDERER_RELEASE_IDENTITY_PLIST must be absolute")
+    }
+    let identityURL = URL(fileURLWithPath: rawIdentityPath).standardizedFileURL
+    guard FileManager.default.fileExists(atPath: identityURL.path) else {
+        fatalError("DORY_RENDERER_RELEASE_IDENTITY_PLIST is unavailable")
+    }
+    dorydRendererReleaseIdentityLinkerSettings = [
+        .unsafeFlags([
+            "-Xlinker", "-sectcreate",
+            "-Xlinker", "__TEXT",
+            "-Xlinker", "__doryid",
+            "-Xlinker", identityURL.path,
+        ]),
+    ]
+} else {
+    dorydRendererReleaseIdentityLinkerSettings = []
+}
+
 let package = Package(
     name: "dory-core-swift",
     platforms: [.macOS(.v14)],
@@ -80,7 +103,8 @@ let package = Package(
         ),
         .executableTarget(
             name: "doryd",
-            dependencies: ["DorydKit"]
+            dependencies: ["DorydKit"],
+            linkerSettings: dorydRendererReleaseIdentityLinkerSettings
         ),
         .executableTarget(
             name: "dorydctl",

--- a/dory-core-swift/Sources/DorydKit/DoryDaemonVirtualMachineProductionTrust.swift
+++ b/dory-core-swift/Sources/DorydKit/DoryDaemonVirtualMachineProductionTrust.swift
@@ -413,7 +413,7 @@ struct DoryDaemonVirtualMachineVerifiedTrustMaterial: Sendable {
     var permitsLegacyCompatibilityMigration: Bool
     /// This provider is installed into production start authority only after the live daemon has
     /// passed its complete signing-identity proof. It remains lazy so non-renderer launches never
-    /// depend on the renderer entitlement.
+    /// depend on the embedded renderer release identity.
     var rendererReleaseIdentityProvider: any DoryRendererReleaseIdentityProviding
     var runtimeVerifier: @Sendable (
         String, MachineBackendDescriptor, String
@@ -1209,7 +1209,7 @@ public struct DoryDaemonVirtualMachineProductionTrustFactory: Sendable {
         hostProbe = Self.probeProductionHost
         daemonIdentityVerifier = DorydXPCSecurity
             .currentProcessSatisfiesProductionDaemonRequirement
-        rendererReleaseIdentityProvider = DoryCurrentTaskRendererReleaseIdentityProvider()
+        rendererReleaseIdentityProvider = DoryEmbeddedRendererReleaseIdentityProvider()
         planningTransactionAvailable = { false }
         synchronizeTrustFloorDirectory = { fsync($0) == 0 }
         trustFloorActivator = { stateDirectory, authority, synchronizeDirectory in
@@ -1228,7 +1228,7 @@ public struct DoryDaemonVirtualMachineProductionTrustFactory: Sendable {
         daemonIdentityVerifier: @escaping @Sendable () -> Bool,
         rendererReleaseIdentityProvider:
             any DoryRendererReleaseIdentityProviding =
-                DoryCurrentTaskRendererReleaseIdentityProvider(),
+                DoryEmbeddedRendererReleaseIdentityProvider(),
         planningTransactionAvailable: @escaping @Sendable () -> Bool = { false },
         synchronizeTrustFloorDirectory: @escaping DirectorySynchronizer = { fsync($0) == 0 },
         trustFloorActivator: TrustFloorActivator? = nil

--- a/dory-core-swift/Sources/DorydKit/DoryRendererReleaseIdentity.swift
+++ b/dory-core-swift/Sources/DorydKit/DoryRendererReleaseIdentity.swift
@@ -1,15 +1,15 @@
 import DoryOperations
 import DoryRendererWorkerWireContracts
 import Foundation
+import MachO
 import Security
 
 /// Fail-closed decoding and acquisition failures for the renderer identity sealed into the live
-/// production daemon. The entitlement is an identity carrier only; it grants no OS privilege.
+/// production daemon's signed Mach-O image.
 enum DoryRendererReleaseIdentityError: Error, Equatable, Sendable {
     case productionDaemonIdentityUnavailable
-    case currentTaskUnavailable
-    case entitlementUnavailable
-    case nonCanonicalEntitlement
+    case embeddedIdentityUnavailable
+    case nonCanonicalIdentity
     case unsupportedSchemaVersion(Int)
     case invalidCodeDirectoryHash(field: String)
     case tupleDefinitionMismatch
@@ -19,7 +19,8 @@ enum DoryRendererReleaseIdentityError: Error, Equatable, Sendable {
 /// signatures and before doryd receives its final signature. It intentionally does not contain
 /// doryd's own CDHash.
 struct DoryRendererReleaseIdentityV1: Equatable, Sendable {
-    static let entitlementName = "com.pythonxi.dory.renderer-release-identity.v1"
+    static let machOSegmentName = "__TEXT"
+    static let machOSectionName = "__doryid"
     static let schemaVersion = 1
 
     private static let schemaVersionKey = "schema-version"
@@ -37,19 +38,19 @@ struct DoryRendererReleaseIdentityV1: Equatable, Sendable {
     let rendererWorkerCodeDirectoryHash: DoryCodeDirectoryHash
     let tupleDefinitionSHA256: DoryRendererArtifactDigest
 
-    /// Decodes the already-parsed entitlement value. Exact keys, scalar types, lowercase hash
+    /// Decodes the already-parsed embedded plist. Exact keys, scalar types, lowercase hash
     /// spellings, and the compiled tuple definition are all part of the canonical form.
-    static func decode(entitlementDictionary: [String: Any]) throws -> Self {
-        guard Set(entitlementDictionary.keys) == canonicalKeys,
+    static func decode(identityDictionary: [String: Any]) throws -> Self {
+        guard Set(identityDictionary.keys) == canonicalKeys,
               let rawSchemaVersion = exactInteger(
-                entitlementDictionary[schemaVersionKey]
+                identityDictionary[schemaVersionKey]
               ),
-              let runnerCDHash = entitlementDictionary[runnerCDHashKey] as? String,
+              let runnerCDHash = identityDictionary[runnerCDHashKey] as? String,
               let rendererWorkerCDHash =
-                entitlementDictionary[rendererWorkerCDHashKey] as? String,
+                identityDictionary[rendererWorkerCDHashKey] as? String,
               let tupleDefinitionSHA256 =
-                entitlementDictionary[tupleDefinitionSHA256Key] as? String else {
-            throw DoryRendererReleaseIdentityError.nonCanonicalEntitlement
+                identityDictionary[tupleDefinitionSHA256Key] as? String else {
+            throw DoryRendererReleaseIdentityError.nonCanonicalIdentity
         }
         guard rawSchemaVersion == schemaVersion else {
             throw DoryRendererReleaseIdentityError.unsupportedSchemaVersion(
@@ -92,7 +93,7 @@ struct DoryRendererReleaseIdentityV1: Equatable, Sendable {
         } catch {
             // Equality with the compiled definition should make this unreachable, but decoding
             // still fails closed if that compile-time constant is malformed.
-            throw DoryRendererReleaseIdentityError.nonCanonicalEntitlement
+            throw DoryRendererReleaseIdentityError.nonCanonicalIdentity
         }
         return Self(
             runnerCodeDirectoryHash: runner,
@@ -102,7 +103,7 @@ struct DoryRendererReleaseIdentityV1: Equatable, Sendable {
     }
 
     /// Swift can bridge CFBoolean and floating-point NSNumber values through surprising numeric
-    /// casts. Entitlement schema versions accept only a lossless integer CFNumber scalar.
+    /// casts. Embedded identity schema versions accept only a lossless integer CFNumber scalar.
     private static func exactInteger(_ value: Any?) -> Int? {
         guard let value else { return nil }
         let cfValue = value as CFTypeRef
@@ -128,7 +129,7 @@ protocol DoryRendererReleaseIdentityProviding: Sendable {
 
 /// Selects live renderer identity authority only for the exact production capability that can
 /// consume it. This keeps VZ, software display, classic virgl display, and legacy launches free of
-/// renderer-entitlement dependencies while making Venus admission fail closed.
+/// renderer-release-identity dependencies while making Venus admission fail closed.
 enum DoryProductionRendererReleaseIdentityAuthority {
     static func resolve(
         backend: DoryVirtualizationBackendIdentity,
@@ -148,9 +149,10 @@ enum DoryProductionRendererReleaseIdentityAuthority {
     }
 }
 
-/// Reads the entitlement attached to the live doryd task, after proving that the task satisfies
-/// doryd's complete production requirement. Adjacent files and bundle metadata are never inputs.
-struct DoryCurrentTaskRendererReleaseIdentityProvider:
+/// Reads the canonical identity plist embedded in the live doryd Mach-O after proving that the
+/// running task satisfies doryd's complete production requirement. The __TEXT section is covered
+/// by doryd's own Code Directory, so no adjacent file or mutable bundle metadata is trusted.
+struct DoryEmbeddedRendererReleaseIdentityProvider:
     DoryRendererReleaseIdentityProviding,
     Sendable
 {
@@ -158,21 +160,43 @@ struct DoryCurrentTaskRendererReleaseIdentityProvider:
         guard DorydXPCSecurity.currentProcessSatisfiesProductionDaemonRequirement() else {
             throw DoryRendererReleaseIdentityError.productionDaemonIdentityUnavailable
         }
-        guard let task = SecTaskCreateFromSelf(nil) else {
-            throw DoryRendererReleaseIdentityError.currentTaskUnavailable
+        guard let data = Self.embeddedIdentityData() else {
+            throw DoryRendererReleaseIdentityError.embeddedIdentityUnavailable
         }
-        guard let value = SecTaskCopyValueForEntitlement(
-            task,
-            DoryRendererReleaseIdentityV1.entitlementName as CFString,
-            nil
-        ) else {
-            throw DoryRendererReleaseIdentityError.entitlementUnavailable
+        let value: Any
+        do {
+            value = try PropertyListSerialization.propertyList(
+                from: data,
+                options: [],
+                format: nil
+            )
+        } catch {
+            throw DoryRendererReleaseIdentityError.nonCanonicalIdentity
         }
         guard let dictionary = value as? [String: Any] else {
-            throw DoryRendererReleaseIdentityError.nonCanonicalEntitlement
+            throw DoryRendererReleaseIdentityError.nonCanonicalIdentity
         }
-        return try DoryRendererReleaseIdentityV1.decode(
-            entitlementDictionary: dictionary
+        return try DoryRendererReleaseIdentityV1.decode(identityDictionary: dictionary)
+    }
+
+    private static func embeddedIdentityData() -> Data? {
+        guard let imageHeader = _dyld_get_image_header(0),
+              imageHeader.pointee.magic == MH_MAGIC_64 else {
+            return nil
+        }
+        let header = UnsafeRawPointer(imageHeader)
+            .assumingMemoryBound(to: mach_header_64.self)
+        var size: UInt = 0
+        let bytes = getsectiondata(
+            header,
+            DoryRendererReleaseIdentityV1.machOSegmentName,
+            DoryRendererReleaseIdentityV1.machOSectionName,
+            &size
         )
+        guard let bytes, size > 0, size <= 1_048_576,
+              let count = Int(exactly: size) else {
+            return nil
+        }
+        return Data(bytes: bytes, count: count)
     }
 }

--- a/dory-core-swift/Tests/DorydKitTests/DoryRendererReleaseIdentityTests.swift
+++ b/dory-core-swift/Tests/DorydKitTests/DoryRendererReleaseIdentityTests.swift
@@ -10,11 +10,11 @@ struct DoryRendererReleaseIdentityTests {
     private let runnerCDHash = String(repeating: "a1", count: 20)
     private let workerCDHash = String(repeating: "ab", count: 20)
 
-    @Test("canonical entitlement binds the directed release chain")
-    func canonicalEntitlement() throws {
+    @Test("canonical embedded identity binds the directed release chain")
+    func canonicalEmbeddedIdentity() throws {
         let dictionary = fixture()
         let identity = try DoryRendererReleaseIdentityV1.decode(
-            entitlementDictionary: dictionary
+            identityDictionary: dictionary
         )
 
         #expect(identity.runnerCodeDirectoryHash.lowercaseHexadecimal == runnerCDHash)
@@ -29,29 +29,29 @@ struct DoryRendererReleaseIdentityTests {
         #expect(try provider.loadReleaseIdentity() == identity)
     }
 
-    @Test("entitlement rejects missing extra and mistyped fields")
+    @Test("embedded identity rejects missing extra and mistyped fields")
     func rejectsNonCanonicalShape() {
         var dictionary = fixture()
         dictionary.removeValue(forKey: "runner-cdhash")
-        #expect(throws: DoryRendererReleaseIdentityError.nonCanonicalEntitlement) {
+        #expect(throws: DoryRendererReleaseIdentityError.nonCanonicalIdentity) {
             _ = try DoryRendererReleaseIdentityV1.decode(
-                entitlementDictionary: dictionary
+                identityDictionary: dictionary
             )
         }
 
         dictionary = fixture()
         dictionary["unreviewed"] = "value"
-        #expect(throws: DoryRendererReleaseIdentityError.nonCanonicalEntitlement) {
+        #expect(throws: DoryRendererReleaseIdentityError.nonCanonicalIdentity) {
             _ = try DoryRendererReleaseIdentityV1.decode(
-                entitlementDictionary: dictionary
+                identityDictionary: dictionary
             )
         }
 
         dictionary = fixture()
         dictionary["schema-version"] = "1"
-        #expect(throws: DoryRendererReleaseIdentityError.nonCanonicalEntitlement) {
+        #expect(throws: DoryRendererReleaseIdentityError.nonCanonicalIdentity) {
             _ = try DoryRendererReleaseIdentityV1.decode(
-                entitlementDictionary: dictionary
+                identityDictionary: dictionary
             )
         }
 
@@ -62,21 +62,21 @@ struct DoryRendererReleaseIdentityTests {
         ] {
             dictionary = fixture()
             dictionary["schema-version"] = wrongNumberType
-            #expect(throws: DoryRendererReleaseIdentityError.nonCanonicalEntitlement) {
+            #expect(throws: DoryRendererReleaseIdentityError.nonCanonicalIdentity) {
                 _ = try DoryRendererReleaseIdentityV1.decode(
-                    entitlementDictionary: dictionary
+                    identityDictionary: dictionary
                 )
             }
         }
     }
 
-    @Test("entitlement rejects unsupported generations and tuple drift")
+    @Test("embedded identity rejects unsupported generations and tuple drift")
     func rejectsVersionAndTupleDrift() {
         var dictionary = fixture()
         dictionary["schema-version"] = 2
         #expect(throws: DoryRendererReleaseIdentityError.unsupportedSchemaVersion(2)) {
             _ = try DoryRendererReleaseIdentityV1.decode(
-                entitlementDictionary: dictionary
+                identityDictionary: dictionary
             )
         }
 
@@ -84,12 +84,12 @@ struct DoryRendererReleaseIdentityTests {
         dictionary["tuple-definition-sha256"] = String(repeating: "cd", count: 32)
         #expect(throws: DoryRendererReleaseIdentityError.tupleDefinitionMismatch) {
             _ = try DoryRendererReleaseIdentityV1.decode(
-                entitlementDictionary: dictionary
+                identityDictionary: dictionary
             )
         }
     }
 
-    @Test("entitlement requires canonical nonzero CDHashes")
+    @Test("embedded identity requires canonical nonzero CDHashes")
     func rejectsInvalidCDHashes() {
         var dictionary = fixture()
         dictionary["runner-cdhash"] = runnerCDHash.uppercased()
@@ -97,7 +97,7 @@ struct DoryRendererReleaseIdentityTests {
             field: "runner-cdhash"
         )) {
             _ = try DoryRendererReleaseIdentityV1.decode(
-                entitlementDictionary: dictionary
+                identityDictionary: dictionary
             )
         }
 
@@ -107,7 +107,7 @@ struct DoryRendererReleaseIdentityTests {
             field: "renderer-worker-cdhash"
         )) {
             _ = try DoryRendererReleaseIdentityV1.decode(
-                entitlementDictionary: dictionary
+                identityDictionary: dictionary
             )
         }
     }
@@ -137,7 +137,7 @@ struct DoryRendererReleaseIdentityTests {
     @Test("production pre-spawn selects identity only for RawHV hardware 3D")
     func productionPreSpawnSelection() throws {
         let identity = try DoryRendererReleaseIdentityV1.decode(
-            entitlementDictionary: fixture()
+            identityDictionary: fixture()
         )
         let selected = try DoryProductionRendererReleaseIdentityAuthority.resolve(
             backend: .doryHypervisor,
@@ -165,7 +165,7 @@ struct DoryRendererReleaseIdentityTests {
     @Test("production pre-spawn rejects typed tuple drift")
     func productionPreSpawnRejectsTupleDrift() throws {
         let canonical = try DoryRendererReleaseIdentityV1.decode(
-            entitlementDictionary: fixture()
+            identityDictionary: fixture()
         )
         let drifted = DoryRendererReleaseIdentityV1(
             runnerCodeDirectoryHash: canonical.runnerCodeDirectoryHash,
@@ -204,7 +204,7 @@ struct DoryRendererReleaseIdentityTests {
 
     private struct RejectingProvider: DoryRendererReleaseIdentityProviding {
         func loadReleaseIdentity() throws -> DoryRendererReleaseIdentityV1 {
-            throw DoryRendererReleaseIdentityError.entitlementUnavailable
+            throw DoryRendererReleaseIdentityError.embeddedIdentityUnavailable
         }
     }
 }

--- a/scripts/bundle-engine.sh
+++ b/scripts/bundle-engine.sh
@@ -346,6 +346,9 @@ build_swiftpm_product_for_arch() {
   local package="$1" configuration="$2" product="$3" arch="$4" package_abs scratch triple bin_path
   package_abs="$(cd "$package" && pwd)"
   scratch="$package_abs/.build/bundle-$configuration-$arch"
+  if [ "$product" = doryd ] && [ -n "${DORY_RENDERER_RELEASE_IDENTITY_PLIST:-}" ]; then
+    scratch="$package_abs/.build/bundle-$configuration-$arch-renderer-release-identity"
+  fi
   triple="$(darwin_triple_for_arch "$arch")"
   swift build --package-path "$package_abs" -c "$configuration" --triple "$triple" \
     --scratch-path "$scratch" --product "$product" >&2
@@ -467,28 +470,8 @@ renderer_release_identity_mode() {
   printf '%s\n' "$mode"
 }
 
-codesign_production_release_identity() {
-  local path="$1" entitlements="$2" id="${DORY_SIGN_ID:-Developer ID Application}"
-  local _attempt error_file
-  [ "$id" != - ] \
-    || { echo "    ERROR: production renderer release identity cannot use ad-hoc signing" >&2; return 1; }
-  error_file="$(mktemp "${TMPDIR:-/tmp}/dory-release-identity-codesign.XXXXXX")"
-  for _attempt in 1 2 3; do
-    if /usr/bin/codesign --force --options runtime --timestamp --identifier doryd \
-        --entitlements "$entitlements" --sign "$id" "$path" 2>"$error_file"; then
-      rm -f "$error_file"
-      return 0
-    fi
-    sleep 2
-  done
-  echo "    ERROR: final production doryd signing failed (identity: $id):" >&2
-  sed 's/^/      /' "$error_file" >&2
-  rm -f "$error_file"
-  return 1
-}
-
 finalize_doryd_signature() {
-  local mode expected_team temporary entitlements
+  local mode expected_team temporary identity_plist configuration
   [ "${DORY_BUNDLE_DORYD:-1}" = 1 ] || return 0
   [ -x "$DORYD_EXECUTABLE" ] && [ ! -L "$DORYD_EXECUTABLE" ] \
     || { echo "    ERROR: deferred doryd executable is missing or indirect" >&2; return 1; }
@@ -509,22 +492,27 @@ finalize_doryd_signature() {
   [ "$expected_team" = 864H636QW4 ] \
     || { echo "    ERROR: production renderer release identity requires Dory team 864H636QW4" >&2; return 1; }
 
-  echo "==> Binding final Runner + Worker Code Directory hashes into doryd…"
+  echo "==> Embedding final Runner + Worker Code Directory hashes into doryd…"
   temporary="$(mktemp -d "${TMPDIR:-/tmp}/dory-renderer-release-identity.XXXXXX")"
-  entitlements="$temporary/doryd-renderer-release-identity.entitlements"
+  identity_plist="$temporary/doryd-renderer-release-identity.plist"
+  configuration="${DORY_DORYD_HELPER_CONFIGURATION:-release}"
   (
-    trap 'rm -f "$entitlements"; rmdir "$temporary" 2>/dev/null || true' EXIT
-    python3 "$REPO_ROOT/scripts/renderer-release-identity.py" create-entitlements \
+    trap 'rm -f "$identity_plist"; rmdir "$temporary" 2>/dev/null || true' EXIT
+    python3 "$REPO_ROOT/scripts/renderer-release-identity.py" create-plist \
       --runner-app "$HV_RUNNER_APP" \
       --expected-team "$expected_team" \
-      --output "$entitlements"
-    codesign_production_release_identity "$DORYD_EXECUTABLE" "$entitlements"
+      --output "$identity_plist"
+    export DORY_RENDERER_RELEASE_IDENTITY_PLIST="$identity_plist"
+    assemble_swiftpm_executable \
+      "dory-core-swift" "$configuration" doryd "$DORYD_EXECUTABLE"
+    unset DORY_RENDERER_RELEASE_IDENTITY_PLIST
+    sign_runtime_payload "$DORYD_EXECUTABLE"
     python3 "$REPO_ROOT/scripts/renderer-release-identity.py" verify \
       --runner-app "$HV_RUNNER_APP" \
       --doryd "$DORYD_EXECUTABLE" \
       --expected-team "$expected_team"
   )
-  echo "    sealed Helpers/doryd after the immutable runner graph"
+  echo "    sealed Helpers/doryd with an executable, entitlement-free renderer identity"
 }
 
 find_debugfs() {

--- a/scripts/release-candidate-live-smoke.sh
+++ b/scripts/release-candidate-live-smoke.sh
@@ -15,6 +15,7 @@ APP="$(cd "$(dirname "$APP")" && pwd)/$(basename "$APP")"
 EXECUTABLE="$APP/Contents/MacOS/Dory"
 DORY_CLI="$APP/Contents/Helpers/dory"
 DOCKER_CLI="$APP/Contents/Helpers/docker"
+HV_RUNNER_EXECUTABLE="$APP/Contents/Helpers/DoryHVRunner.app/Contents/MacOS/dory-hv"
 SERVICE="gui/$(id -u)/dev.dory.doryd"
 PLIST="$HOME/Library/LaunchAgents/dev.dory.doryd.plist"
 STATE="$HOME/.dory"
@@ -203,7 +204,7 @@ fi
 for helper in \
   "$EXECUTABLE" "$DORY_CLI" "$DOCKER_CLI" \
   "$APP/Contents/Helpers/dory-doctor" "$APP/Contents/Helpers/dorydctl" \
-  "$APP/Contents/Helpers/doryd" "$APP/Contents/Helpers/dory-hv" \
+  "$APP/Contents/Helpers/doryd" "$HV_RUNNER_EXECUTABLE" \
   "$APP/Contents/Helpers/dory-vmm"; do
   [ -f "$helper" ] && [ ! -L "$helper" ] && [ -x "$helper" ] \
     || fail "candidate executable is unavailable or indirect: $helper"
@@ -379,7 +380,7 @@ hv_pid_count="$(printf '%s\n' "$hv_pid_list" | awk 'NF { count++ } END { print c
 hv_pid="$(printf '%s\n' "$hv_pid_list" | awk 'NF { print; exit }')"
 hv_command="$(ps -ww -p "$hv_pid" -o command=)"
 printf '%s\n' "$hv_command" > "$LOG_ROOT/dory-hv-command.txt"
-grep -Fq "$APP/Contents/Helpers/dory-hv" <<< "$hv_command" \
+grep -Fq "$HV_RUNNER_EXECUTABLE" <<< "$hv_command" \
   || fail "running dory-hv helper does not come from the candidate app: $hv_command"
 
 if [ "$REQUIRED_ARCH" = arm64 ]; then
@@ -579,7 +580,7 @@ fi
   echo "app_executable_sha256=$(shasum -a 256 "$EXECUTABLE" | awk '{print $1}')"
   echo "docker_sha256=$(shasum -a 256 "$DOCKER_CLI" | awk '{print $1}')"
   echo "doryd_sha256=$(shasum -a 256 "$APP/Contents/Helpers/doryd" | awk '{print $1}')"
-  echo "dory_hv_sha256=$(shasum -a 256 "$APP/Contents/Helpers/dory-hv" | awk '{print $1}')"
+  echo "dory_hv_sha256=$(shasum -a 256 "$HV_RUNNER_EXECUTABLE" | awk '{print $1}')"
   echo "dory_vmm_sha256=$(shasum -a 256 "$APP/Contents/Helpers/dory-vmm" | awk '{print $1}')"
   echo "fixture_image=$FIXTURE_IMAGE"
   echo "nonnative_build_image=$NONNATIVE_BUILD_IMAGE"

--- a/scripts/renderer-release-identity.py
+++ b/scripts/renderer-release-identity.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Create and verify doryd's directed production renderer release identity."""
+"""Create and verify doryd's signed, embedded renderer release identity."""
 
 from __future__ import annotations
 
@@ -9,6 +9,7 @@ import pathlib
 import plistlib
 import re
 import stat
+import struct
 import subprocess
 import sys
 from typing import NoReturn
@@ -20,8 +21,9 @@ RUNNER_EXECUTABLE = "dory-hv"
 WORKER_IDENTIFIER = "com.pythonxi.Dory.HVRunner.RendererWorker"
 WORKER_EXECUTABLE = "DoryRendererWorker"
 DORYD_IDENTIFIER = "doryd"
-ENTITLEMENT_NAME = "com.pythonxi.dory.renderer-release-identity.v1"
-ENTITLEMENT_SCHEMA_VERSION = 1
+IDENTITY_SEGMENT_NAME = "__TEXT"
+IDENTITY_SECTION_NAME = "__doryid"
+IDENTITY_SCHEMA_VERSION = 1
 IDENTITY_KEYS = frozenset({
     "schema-version",
     "runner-cdhash",
@@ -277,7 +279,7 @@ def tuple_definition_digest(repo_root: pathlib.Path) -> str:
     return parse_tuple_definition_digest(output)
 
 
-def release_identity_entitlements(
+def release_identity_payload(
     *, runner_cdhash: str, worker_cdhash: str, tuple_digest: str
 ) -> dict[str, object]:
     for value, label in (
@@ -289,43 +291,38 @@ def release_identity_entitlements(
     if not HASH_64.fullmatch(tuple_digest) or tuple_digest == "0" * 64:
         fail("tuple-definition-sha256 must be nonzero canonical 64-hex")
     return {
-        ENTITLEMENT_NAME: {
-            "schema-version": ENTITLEMENT_SCHEMA_VERSION,
-            "runner-cdhash": runner_cdhash,
-            "renderer-worker-cdhash": worker_cdhash,
-            "tuple-definition-sha256": tuple_digest,
-        }
+        "schema-version": IDENTITY_SCHEMA_VERSION,
+        "runner-cdhash": runner_cdhash,
+        "renderer-worker-cdhash": worker_cdhash,
+        "tuple-definition-sha256": tuple_digest,
     }
 
 
-def validate_release_identity_entitlements(
+def validate_release_identity_payload(
     value: dict[str, object], expected: dict[str, object]
 ) -> None:
-    if set(value) != {ENTITLEMENT_NAME}:
-        fail("doryd entitlement top level must contain only the renderer release identity")
-    nested = value.get(ENTITLEMENT_NAME)
-    if not isinstance(nested, dict) or set(nested) != IDENTITY_KEYS:
+    if set(value) != IDENTITY_KEYS:
         fail("doryd renderer release identity has a noncanonical key set")
-    if type(nested.get("schema-version")) is not int:  # bool is not an integer here.
+    if type(value.get("schema-version")) is not int:  # bool is not an integer here.
         fail("doryd renderer release identity schema-version must be an integer")
     for field in (
         "runner-cdhash",
         "renderer-worker-cdhash",
         "tuple-definition-sha256",
     ):
-        if type(nested.get(field)) is not str:
+        if type(value.get(field)) is not str:
             fail(f"doryd renderer release identity {field} must be a string")
     if value != expected:
         fail("doryd renderer release identity differs from the final signed graph")
 
 
-def canonical_entitlement_bytes(value: dict[str, object]) -> bytes:
+def canonical_identity_bytes(value: dict[str, object]) -> bytes:
     return plistlib.dumps(value, fmt=plistlib.FMT_XML, sort_keys=True)
 
 
-def write_entitlements(path: pathlib.Path, value: dict[str, object]) -> None:
-    direct_directory(path.parent, "entitlement temporary directory")
-    raw = canonical_entitlement_bytes(value)
+def write_identity_plist(path: pathlib.Path, value: dict[str, object]) -> None:
+    direct_directory(path.parent, "identity temporary directory")
+    raw = canonical_identity_bytes(value)
     try:
         with path.open("xb") as handle:
             handle.write(raw)
@@ -333,10 +330,10 @@ def write_entitlements(path: pathlib.Path, value: dict[str, object]) -> None:
             os.fsync(handle.fileno())
         os.chmod(path, 0o600)
     except OSError as error:
-        fail(f"cannot create canonical temporary doryd entitlement: {error}")
+        fail(f"cannot create canonical temporary doryd identity: {error}")
     if path.read_bytes() != raw:
-        fail("canonical temporary doryd entitlement changed after creation")
-    validate_release_identity_entitlements(read_plist(path, "doryd entitlement"), value)
+        fail("canonical temporary doryd identity changed after creation")
+    validate_release_identity_payload(read_plist(path, "doryd identity"), value)
 
 
 def read_signed_entitlements(
@@ -359,21 +356,165 @@ def read_signed_entitlements(
     return value
 
 
-def create_entitlements(arguments: argparse.Namespace) -> None:
+def decode_macho_name(raw: bytes) -> str:
+    try:
+        return raw.split(b"\0", 1)[0].decode("ascii")
+    except UnicodeDecodeError as error:
+        fail(f"Mach-O section name is not ASCII: {error}")
+
+
+def read_identity_from_thin_macho(raw: bytes) -> bytes | None:
+    if len(raw) < 32:
+        fail("doryd Mach-O header is truncated")
+    magic, _, _, _, command_count, command_bytes, _, _ = struct.unpack_from(
+        "<IiiIIIII", raw, 0
+    )
+    if magic != 0xFEEDFACF:
+        fail("doryd release identity requires a thin little-endian 64-bit Mach-O")
+    commands_end = 32 + command_bytes
+    if commands_end > len(raw):
+        fail("doryd Mach-O load-command table is truncated")
+
+    matches: list[bytes] = []
+    cursor = 32
+    for _ in range(command_count):
+        if cursor + 8 > commands_end:
+            fail("doryd Mach-O load command is truncated")
+        command, command_size = struct.unpack_from("<II", raw, cursor)
+        if command_size < 8 or cursor + command_size > commands_end:
+            fail("doryd Mach-O load command has an invalid size")
+        if command == 0x19:  # LC_SEGMENT_64
+            if command_size < 72:
+                fail("doryd LC_SEGMENT_64 command is truncated")
+            segment_name = decode_macho_name(raw[cursor + 8:cursor + 24])
+            section_count = struct.unpack_from("<I", raw, cursor + 64)[0]
+            expected_size = 72 + section_count * 80
+            if expected_size > command_size:
+                fail("doryd LC_SEGMENT_64 section table is truncated")
+            section_cursor = cursor + 72
+            for _ in range(section_count):
+                section_name = decode_macho_name(
+                    raw[section_cursor:section_cursor + 16]
+                )
+                declared_segment = decode_macho_name(
+                    raw[section_cursor + 16:section_cursor + 32]
+                )
+                section_size = struct.unpack_from("<Q", raw, section_cursor + 40)[0]
+                section_offset = struct.unpack_from("<I", raw, section_cursor + 48)[0]
+                if (
+                    segment_name == IDENTITY_SEGMENT_NAME
+                    and declared_segment == IDENTITY_SEGMENT_NAME
+                    and section_name == IDENTITY_SECTION_NAME
+                ):
+                    end = section_offset + section_size
+                    if (
+                        section_size == 0
+                        or section_size > MAX_PLIST_BYTES
+                        or section_offset < commands_end
+                        or end > len(raw)
+                    ):
+                        fail("doryd embedded renderer identity has invalid bounds")
+                    matches.append(raw[section_offset:end])
+                section_cursor += 80
+        cursor += command_size
+    if cursor != commands_end:
+        fail("doryd Mach-O load-command sizes are noncanonical")
+    if len(matches) > 1:
+        fail("doryd contains duplicate renderer release-identity sections")
+    return matches[0] if matches else None
+
+
+def macho_slices(raw: bytes) -> list[bytes]:
+    if len(raw) < 8:
+        fail("doryd Mach-O container is truncated")
+    big_magic = struct.unpack_from(">I", raw, 0)[0]
+    little_magic = struct.unpack_from("<I", raw, 0)[0]
+    if little_magic == 0xFEEDFACF:
+        return [raw]
+    if big_magic in {0xCAFEBABE, 0xCAFEBABF}:
+        endian = ">"
+        is_64 = big_magic == 0xCAFEBABF
+    elif little_magic in {0xCAFEBABE, 0xCAFEBABF}:
+        endian = "<"
+        is_64 = little_magic == 0xCAFEBABF
+    else:
+        fail("doryd release identity requires a 64-bit Mach-O")
+
+    architecture_count = struct.unpack_from(endian + "I", raw, 4)[0]
+    if architecture_count == 0 or architecture_count > 32:
+        fail("doryd universal Mach-O has an invalid architecture count")
+    entry_size = 32 if is_64 else 20
+    table_end = 8 + architecture_count * entry_size
+    if table_end > len(raw):
+        fail("doryd universal Mach-O architecture table is truncated")
+    slices: list[bytes] = []
+    occupied: list[tuple[int, int]] = []
+    cursor = 8
+    for _ in range(architecture_count):
+        if is_64:
+            _, _, offset, size, _, _ = struct.unpack_from(
+                endian + "iiQQII", raw, cursor
+            )
+        else:
+            _, _, offset, size, _ = struct.unpack_from(
+                endian + "iiIII", raw, cursor
+            )
+        end = offset + size
+        if size == 0 or offset < table_end or end > len(raw):
+            fail("doryd universal Mach-O slice has invalid bounds")
+        if any(offset < prior_end and prior_offset < end
+               for prior_offset, prior_end in occupied):
+            fail("doryd universal Mach-O slices overlap")
+        occupied.append((offset, end))
+        slices.append(raw[offset:end])
+        cursor += entry_size
+    return slices
+
+
+def read_embedded_identity_bytes(path: pathlib.Path) -> bytes | None:
+    """Return the consistent __TEXT,__doryid section without invoking a tool."""
+    raw = direct_regular_file(path, "doryd", executable=True).read_bytes()
+    sections = [read_identity_from_thin_macho(value) for value in macho_slices(raw)]
+    present = [value for value in sections if value is not None]
+    if not present:
+        return None
+    if len(present) != len(sections):
+        fail("doryd renderer release identity is missing from one Mach-O slice")
+    if any(value != present[0] for value in present[1:]):
+        fail("doryd renderer release identity differs across Mach-O slices")
+    return present[0]
+
+
+def read_embedded_identity(path: pathlib.Path) -> dict[str, object] | None:
+    raw = read_embedded_identity_bytes(path)
+    if raw is None:
+        return None
+    try:
+        value = plistlib.loads(raw)
+    except plistlib.InvalidFileException as error:
+        fail(f"doryd embedded renderer identity is not a plist: {error}")
+    if not isinstance(value, dict):
+        fail("doryd embedded renderer identity root must be a dictionary")
+    if canonical_identity_bytes(value) != raw:
+        fail("doryd embedded renderer identity is not canonical XML")
+    return value
+
+
+def create_identity_plist(arguments: argparse.Namespace) -> None:
     runner_cdhash, worker_cdhash = verify_runner_graph(
         arguments.runner_app, arguments.expected_team
     )
     tuple_digest = tuple_definition_digest(arguments.repo_root)
-    value = release_identity_entitlements(
+    value = release_identity_payload(
         runner_cdhash=runner_cdhash,
         worker_cdhash=worker_cdhash,
         tuple_digest=tuple_digest,
     )
-    write_entitlements(arguments.output, value)
+    write_identity_plist(arguments.output, value)
     print(f"renderer.release-identity.runner-cdhash={runner_cdhash}")
     print(f"renderer.release-identity.worker-cdhash={worker_cdhash}")
     print(f"renderer.release-identity.tuple-definition-sha256={tuple_digest}")
-    print(f"renderer.release-identity.entitlements={arguments.output}")
+    print(f"renderer.release-identity.plist={arguments.output}")
 
 
 def verify_identity(arguments: argparse.Namespace) -> None:
@@ -383,7 +524,7 @@ def verify_identity(arguments: argparse.Namespace) -> None:
         arguments.runner_app, arguments.expected_team
     )
     tuple_digest = tuple_definition_digest(arguments.repo_root)
-    expected = release_identity_entitlements(
+    expected = release_identity_payload(
         runner_cdhash=runner_cdhash,
         worker_cdhash=worker_cdhash,
         tuple_digest=tuple_digest,
@@ -394,9 +535,12 @@ def verify_identity(arguments: argparse.Namespace) -> None:
         expected_identifier=DORYD_IDENTIFIER,
         expected_team=arguments.expected_team,
     )
-    validate_release_identity_entitlements(
-        read_signed_entitlements(doryd, "doryd"), expected
-    )
+    if read_signed_entitlements(doryd, "doryd", allow_empty=True):
+        fail("production doryd must not carry custom entitlements")
+    embedded = read_embedded_identity(doryd)
+    if embedded is None:
+        fail("production doryd omits its embedded renderer release identity")
+    validate_release_identity_payload(embedded, expected)
     print(f"renderer.release-identity.runner-cdhash={runner_cdhash}")
     print(f"renderer.release-identity.worker-cdhash={worker_cdhash}")
     print(f"renderer.release-identity.tuple-definition-sha256={tuple_digest}")
@@ -409,6 +553,8 @@ def verify_absent(arguments: argparse.Namespace) -> None:
     entitlements = read_signed_entitlements(doryd, "doryd", allow_empty=True)
     if entitlements:
         fail("non-production doryd must not carry any signed entitlements")
+    if read_embedded_identity(doryd) is not None:
+        fail("non-production doryd must not carry a renderer release identity section")
     print("renderer.release-identity=absent-fail-closed")
 
 
@@ -417,7 +563,7 @@ def parser() -> argparse.ArgumentParser:
     result = argparse.ArgumentParser(description=__doc__)
     commands = result.add_subparsers(dest="command", required=True)
 
-    create = commands.add_parser("create-entitlements")
+    create = commands.add_parser("create-plist")
     create.add_argument("--runner-app", required=True, type=pathlib.Path)
     create.add_argument("--output", required=True, type=pathlib.Path)
     create.add_argument("--expected-team", default=PRODUCTION_TEAM_IDENTIFIER)
@@ -436,15 +582,15 @@ def parser() -> argparse.ArgumentParser:
 
 def main() -> int:
     arguments = parser().parse_args()
-    if arguments.command in {"create-entitlements", "verify"}:
+    if arguments.command in {"create-plist", "verify"}:
         if arguments.expected_team != PRODUCTION_TEAM_IDENTIFIER:
             fail(
                 "renderer release identity can only bind Dory production team "
                 f"{PRODUCTION_TEAM_IDENTIFIER}"
             )
         arguments.repo_root = arguments.repo_root.resolve(strict=True)
-    if arguments.command == "create-entitlements":
-        create_entitlements(arguments)
+    if arguments.command == "create-plist":
+        create_identity_plist(arguments)
     elif arguments.command == "verify":
         verify_identity(arguments)
     elif arguments.command == "verify-absent":


### PR DESCRIPTION
## Root cause

macOS 27 killed the notarized doryd helper before main with OS_REASON_EXEC because the renderer release identity was encoded as a custom signed entitlement. Codesign and notarization accepted the file, but launch-time execution policy did not.

## Fix

- embed the immutable runner/renderer CDHash tuple in a signed __TEXT,__doryid Mach-O section
- keep doryd entitlement-free and verify its Developer ID signature plus exact embedded payload
- rebuild doryd only after the nested runner graph receives its final signatures
- add fail-closed Mach-O parsing, canonical payload tests, and release-order checks
- update physical release smoke checks to use the nested DoryHVRunner executable path

## Verification

- full Swift suite: 447 tests in 50 suites passed, with all XCTest suites passing
- renderer identity Python suite: 9 passed
- live-smoke contract suite: 6 passed
- component packaging contract: passed
- release workflow contract: passed
- Developer ID signed arm64 doryd: exact section verified, no entitlements, reached main under macOS execution policy instead of OS_REASON_EXEC