### PR TITLE
Read published-port inventory in-process instead of curling Docker

### DIFF
--- a/Packages/ContainerizationEngine/Sources/DoryHV/UnixSocketHTTPClient.swift
+++ b/Packages/ContainerizationEngine/Sources/DoryHV/UnixSocketHTTPClient.swift
@@ -11,10 +11,11 @@ public struct UnixSocketHTTPResponse: Equatable, Sendable {
     }
 }
 
-/// A bounded HTTP/1.1 GET used by engine-internal Unix-socket health probes.
+/// A bounded HTTP/1.1 GET used by engine-internal Unix-socket probes (gvproxy health, Docker
+/// `/_ping`, and published-port inventory).
 ///
-/// Keeping this in-process avoids spawning two `curl` processes every probe interval. Responses
-/// are capped before allocation growth, and malformed/truncated/chunked bodies fail closed.
+/// Keeping this in-process avoids spawning `curl` for every probe interval. Responses are capped
+/// before allocation growth, and malformed/truncated/chunked bodies fail closed.
 public enum UnixSocketHTTPClient {
     public static func get(
         socketPath: String,

--- a/Packages/ContainerizationEngine/Sources/dory-hv/PortForwarder.swift
+++ b/Packages/ContainerizationEngine/Sources/dory-hv/PortForwarder.swift
@@ -47,6 +47,7 @@ final class PortForwarder: MachinePortForwarding, @unchecked Sendable {
     private var machineExposed = Set<PublishedPortForward>()
     private var lastForwardFailureLog: [PublishedPortForward: Date] = [:]
     private var lastLANFailureLog = Date.distantPast
+    private var lastInventoryFailureLog = Date.distantPast
     private var recoveringLANSession = false
 
     init(
@@ -130,6 +131,7 @@ final class PortForwarder: MachinePortForwarding, @unchecked Sendable {
         removedSoFar: Int = 0
     ) -> PortForwardReconcileResult {
         guard let ports = publishedPorts() else {
+            logInventoryUnavailable()
             return failure("Docker published-port inventory is unavailable")
         }
         if let client = sourcePreservingLANClient, let sessionID = sourcePreservingLANSessionID {
@@ -316,6 +318,13 @@ final class PortForwarder: MachinePortForwarding, @unchecked Sendable {
         }
     }
 
+    private func logInventoryUnavailable() {
+        let now = Date()
+        guard now.timeIntervalSince(lastInventoryFailureLog) >= 30 else { return }
+        lastInventoryFailureLog = now
+        log("Docker published-port inventory is unavailable")
+    }
+
     private func logLANFailure(_ message: String) {
         let now = Date()
         guard now.timeIntervalSince(lastLANFailureLog) >= 30 else { return }
@@ -326,38 +335,15 @@ final class PortForwarder: MachinePortForwarding, @unchecked Sendable {
     /// The set of host ports currently published by any running container.
     private func publishedPorts() -> Set<PublishedPortBinding>? {
         if let publishedPortsProvider { return publishedPortsProvider() }
-        guard let data = curlData(unixSocket: engineSocket, url: "http://d/v1.41/containers/json"),
-              let containers = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+        guard let response = UnixSocketHTTPClient.get(
+            socketPath: engineSocket,
+            path: PublishedPortForwardPlan.dockerContainerListPath,
+            timeout: 3,
+            maximumBodyBytes: PublishedPortForwardPlan.dockerContainerListMaximumBodyBytes
+        ), (200..<300).contains(response.statusCode) else {
             return nil
         }
-        var ports = Set<PublishedPortBinding>()
-        for container in containers {
-            let labels = container["Labels"] as? [String: String]
-            let loopbackIntents = PublishedPortForwardPlan.loopbackIntents(
-                fromLabel: labels?[PublishedPortForwardPlan.loopbackPortIntentLabel]
-            )
-            guard let list = container["Ports"] as? [[String: Any]] else { continue }
-            for entry in list {
-                let proto = entry["Type"] as? String ?? "tcp"
-                let requestedHost = PublishedPortForwardPlan.requestedHost(
-                    dockerHost: entry["IP"] as? String,
-                    containerPort: entry["PrivatePort"] as? Int,
-                    publicPort: entry["PublicPort"] as? Int,
-                    dockerType: proto,
-                    loopbackIntents: loopbackIntents
-                )
-                guard let publicPort = entry["PublicPort"] as? Int,
-                      let binding = PublishedPortBinding(
-                        dockerType: proto,
-                        publicPort: publicPort,
-                        hostIP: requestedHost
-                      ) else {
-                    continue
-                }
-                ports.insert(binding)
-            }
-        }
-        return ports
+        return PublishedPortForwardPlan.bindings(fromContainersJSON: response.body)
     }
 
     private func expose(_ forward: PublishedPortForward) -> Bool {

--- a/Packages/ContainerizationEngine/Tests/DoryHVTests/GVProxyForwardRegistryTests.swift
+++ b/Packages/ContainerizationEngine/Tests/DoryHVTests/GVProxyForwardRegistryTests.swift
@@ -162,6 +162,78 @@ import Testing
         #expect(result.error?.contains("could not be read after") == true)
     }
 
+    @Test func nilDockerInventoryFailsClosedWithoutMutatingGvproxy() {
+        let registry = ForwardRegistryStub()
+        let calls = ForwardCallRecorder()
+        let logs = LockedStringList()
+        let forwarder = PortForwarder(
+            engineSocket: "/unused/engine.sock",
+            apiSocket: "/unused/gvproxy.sock",
+            guestIP: "192.168.127.2",
+            log: { logs.append($0) },
+            publishedPortsProvider: { nil },
+            registeredForwardsProvider: { registry.snapshot },
+            exposeProvider: { forward in
+                calls.record(.expose(forward))
+                registry.expose(forward)
+                return true
+            },
+            unexposeProvider: { forward in
+                calls.record(.unexpose(forward))
+                registry.unexpose(forward)
+                return true
+            }
+        )
+        defer { forwarder.stop() }
+
+        let result = forwarder.reconcileNow()
+
+        #expect(!result.succeeded)
+        #expect(result.error == "Docker published-port inventory is unavailable")
+        #expect(result.publishedPortCount == 0)
+        #expect(result.desired.isEmpty)
+        #expect(result.missing.isEmpty)
+        #expect(result.unexpected.isEmpty)
+        #expect(calls.operations.isEmpty)
+        #expect(registry.forwards.isEmpty)
+        #expect(logs.strings.contains("Docker published-port inventory is unavailable"))
+    }
+
+    @Test func inProcessContainerListCreatesWantedGvproxyForward() throws {
+        let body = #"[{"Id":"abc","Names":["/web"],"State":"running","Ports":[{"IP":"127.0.0.1","PrivatePort":80,"PublicPort":38099,"Type":"tcp"}]}]"#
+        let server = try RepeatingUnixHTTPServer.containersJSON(body)
+        defer { server.stop() }
+        let wanted = forward(.tcp, host: "127.0.0.1", port: 38_099)
+        let registry = ForwardRegistryStub()
+        let calls = ForwardCallRecorder()
+        let forwarder = PortForwarder(
+            engineSocket: server.path,
+            apiSocket: "/unused/gvproxy.sock",
+            guestIP: "192.168.127.2",
+            log: { _ in },
+            registeredForwardsProvider: { registry.snapshot },
+            exposeProvider: { forward in
+                calls.record(.expose(forward))
+                registry.expose(forward)
+                return true
+            },
+            unexposeProvider: { forward in
+                calls.record(.unexpose(forward))
+                registry.unexpose(forward)
+                return true
+            }
+        )
+        defer { forwarder.stop() }
+
+        let result = forwarder.reconcileNow()
+
+        #expect(result.succeeded)
+        #expect(result.publishedPortCount == 1)
+        #expect(registry.forwards.contains(wanted))
+        #expect(calls.operations == [.expose(wanted)])
+        #expect(server.paths.contains(PublishedPortForwardPlan.dockerContainerListPath))
+    }
+
     @Test func malformedRegistryFailsClosed() {
         #expect(GVProxyForwardRegistry.decode(Data("not-json".utf8)) == nil)
         #expect(GVProxyForwardRegistry.decode(Data(#"""
@@ -306,4 +378,118 @@ private final class LockedInt: @unchecked Sendable {
             return stored
         }
     }
+}
+
+private final class LockedStringList: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: [String] = []
+
+    var strings: [String] { lock.withLock { stored } }
+
+    func append(_ value: String) {
+        lock.withLock { stored.append(value) }
+    }
+}
+
+private final class RepeatingUnixHTTPServer: @unchecked Sendable {
+    let path: String
+    private let fd: Int32
+    private let response: Data
+    private let queue = DispatchQueue(label: "dev.dory.test.repeating-unix-http")
+    private let lock = NSLock()
+    private var storedPaths: [String] = []
+    private var stopped = false
+
+    var paths: [String] { lock.withLock { storedPaths } }
+
+    static func containersJSON(_ body: String) throws -> RepeatingUnixHTTPServer {
+        let header = "HTTP/1.1 200 OK\r\nContent-Length: \(body.utf8.count)\r\nConnection: close\r\n\r\n"
+        return try RepeatingUnixHTTPServer(response: header + body)
+    }
+
+    init(response: String) throws {
+        let base = "/tmp/dory-port-forward-http-\(getpid())-\(UInt32.random(in: 0..<UInt32.max))"
+        try FileManager.default.createDirectory(atPath: base, withIntermediateDirectories: true)
+        path = base + "/server.sock"
+        fd = try repeatingUnixBindListener(path: path)
+        self.response = Data(response.utf8)
+        acceptLoop()
+    }
+
+    func stop() {
+        lock.lock()
+        stopped = true
+        lock.unlock()
+        close(fd)
+        try? FileManager.default.removeItem(atPath: (path as NSString).deletingLastPathComponent)
+    }
+
+    private func acceptLoop() {
+        queue.async { [self] in
+            while true {
+                if lock.withLock({ stopped }) { return }
+                let client = accept(fd, nil, nil)
+                guard client >= 0 else { return }
+                serve(client)
+            }
+        }
+    }
+
+    private func serve(_ client: Int32) {
+        defer { close(client) }
+        var requestBytes = Data()
+        var byte: UInt8 = 0
+        while requestBytes.count < 8_192, Darwin.read(client, &byte, 1) == 1 {
+            requestBytes.append(byte)
+            if requestBytes.suffix(4) == Data("\r\n\r\n".utf8) { break }
+        }
+        let request = String(decoding: requestBytes, as: UTF8.self)
+        let path = request.split(separator: " ").dropFirst().first.map(String.init) ?? ""
+        lock.lock()
+        storedPaths.append(path)
+        lock.unlock()
+        response.withUnsafeBytes { raw in
+            guard let base = raw.baseAddress else { return }
+            var offset = 0
+            while offset < raw.count {
+                let count = Darwin.write(client, base.advanced(by: offset), raw.count - offset)
+                guard count > 0 else { break }
+                offset += count
+            }
+        }
+        shutdown(client, SHUT_WR)
+    }
+}
+
+private enum RepeatingUnixHTTPServerError: Error {
+    case syscall(String, Int32)
+    case pathTooLong
+}
+
+private func repeatingUnixBindListener(path: String) throws -> Int32 {
+    let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+    guard fd >= 0 else { throw RepeatingUnixHTTPServerError.syscall("socket", errno) }
+    var address = sockaddr_un()
+    address.sun_family = sa_family_t(AF_UNIX)
+    let bytes = Array(path.utf8)
+    guard bytes.count < MemoryLayout.size(ofValue: address.sun_path) else {
+        close(fd)
+        throw RepeatingUnixHTTPServerError.pathTooLong
+    }
+    withUnsafeMutableBytes(of: &address.sun_path) { destination in
+        bytes.withUnsafeBytes { source in
+            destination.baseAddress!.copyMemory(from: source.baseAddress!, byteCount: bytes.count)
+        }
+    }
+    let bound = withUnsafePointer(to: &address) { pointer in
+        pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+            Darwin.bind(fd, $0, socklen_t(MemoryLayout<sockaddr_un>.size))
+        }
+    }
+    guard bound == 0, listen(fd, 8) == 0 else {
+        let code = errno
+        close(fd)
+        throw RepeatingUnixHTTPServerError.syscall("bind/listen", code)
+    }
+    return fd
 }

--- a/Packages/ContainerizationEngine/Tests/DoryHVTests/PublishedPortForwardPlanTests.swift
+++ b/Packages/ContainerizationEngine/Tests/DoryHVTests/PublishedPortForwardPlanTests.swift
@@ -2,6 +2,7 @@ import Testing
 @testable import DoryHV
 import DoryCore
 import DoryOperations
+import Foundation
 
 @Suite struct PublishedPortForwardPlanTests {
     @Test func parsesDockerTransportTypes() {
@@ -158,6 +159,31 @@ import DoryOperations
         let label = #"{"0/tcp":{"80":"ipv4"},"8080/sctp":{"80":"ipv4"},"9090/tcp":{"80":"wide"},"bad":{"80":"ipv6"}}"#
         #expect(PublishedPortForwardPlan.loopbackIntents(fromLabel: label).isEmpty)
         #expect(PublishedPortForwardPlan.loopbackIntents(fromLabel: "not-json").isEmpty)
+    }
+
+    @Test func bindingsFromContainersJSONFailClosedOnNonArray() {
+        #expect(PublishedPortForwardPlan.bindings(fromContainersJSON: Data("not-json".utf8)) == nil)
+        #expect(PublishedPortForwardPlan.bindings(fromContainersJSON: Data("{}".utf8)) == nil)
+        #expect(PublishedPortForwardPlan.bindings(fromContainersJSON: Data("[]".utf8)) == [])
+    }
+
+    @Test func bindingsFromContainersJSONReadPublicPorts() throws {
+        let data = Data(#"""
+        [
+          {
+            "Id": "abc",
+            "Labels": {},
+            "Ports": [
+              {"IP": "127.0.0.1", "PrivatePort": 80, "PublicPort": 38099, "Type": "tcp"},
+              {"PrivatePort": 80, "Type": "tcp"}
+            ]
+          }
+        ]
+        """#.utf8)
+        let bindings = try #require(PublishedPortForwardPlan.bindings(fromContainersJSON: data))
+        #expect(bindings == [
+            PublishedPortBinding(protocol: .tcp, port: 38_099, hostIP: "127.0.0.1"),
+        ])
     }
 
     private func forward(

--- a/Packages/ContainerizationEngine/Tests/DoryHVTests/UnixSocketHTTPClientTests.swift
+++ b/Packages/ContainerizationEngine/Tests/DoryHVTests/UnixSocketHTTPClientTests.swift
@@ -1,5 +1,6 @@
 import Darwin
 @testable import DoryHV
+import DoryCore
 import Foundation
 import Testing
 
@@ -51,6 +52,27 @@ struct UnixSocketHTTPClientTests {
     @Test func rejectsHeaderInjectionAndOversizedSocketPaths() {
         #expect(UnixSocketHTTPClient.get(socketPath: "/tmp/missing", path: "/_ping\r\nInjected: yes") == nil)
         #expect(UnixSocketHTTPClient.get(socketPath: "/" + String(repeating: "x", count: 512), path: "/_ping") == nil)
+    }
+
+    @Test func readsDockerContainerListWithinInventoryBodyCap() throws {
+        let body = #"[{"Id":"abc","Ports":[{"IP":"127.0.0.1","PrivatePort":80,"PublicPort":38099,"Type":"tcp"}]}]"#
+        let server = try GVHTTPFakeServer(
+            response: "HTTP/1.1 200 OK\r\nContent-Length: \(body.utf8.count)\r\nConnection: close\r\n\r\n\(body)"
+        )
+        defer { server.stop() }
+
+        let response = try #require(UnixSocketHTTPClient.get(
+            socketPath: server.path,
+            path: PublishedPortForwardPlan.dockerContainerListPath,
+            timeout: 3,
+            maximumBodyBytes: PublishedPortForwardPlan.dockerContainerListMaximumBodyBytes
+        ))
+        #expect(response.statusCode == 200)
+        #expect(PublishedPortForwardPlan.bindings(fromContainersJSON: response.body) == [
+            PublishedPortBinding(protocol: .tcp, port: 38_099, hostIP: "127.0.0.1"),
+        ])
+        #expect(server.wait())
+        #expect(server.request.contains("GET /containers/json HTTP/1.1"))
     }
 }
 

--- a/dory-core-swift/Sources/DoryCore/PublishedPortForwardPlan.swift
+++ b/dory-core-swift/Sources/DoryCore/PublishedPortForwardPlan.swift
@@ -76,6 +76,44 @@ public struct PublishedPortForward: Sendable, Hashable {
 
 public enum PublishedPortForwardPlan {
     public static let loopbackPortIntentLabel = "dev.dory.internal.loopback-port-intent"
+    /// Running-container list used by host-side published-port reconcilers. Stopped containers
+    /// are omitted so gvproxy does not retain stale host listeners.
+    public static let dockerContainerListPath = "/containers/json"
+    public static let dockerContainerListMaximumBodyBytes = 2 * 1_024 * 1_024
+
+    /// Fail closed on a non-array payload. An empty array is a successful empty inventory.
+    public static func bindings(fromContainersJSON data: Data) -> Set<PublishedPortBinding>? {
+        guard let containers = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+            return nil
+        }
+        var ports = Set<PublishedPortBinding>()
+        for container in containers {
+            let labels = container["Labels"] as? [String: String] ?? [:]
+            let loopbackIntents = loopbackIntents(fromLabel: labels[loopbackPortIntentLabel])
+            guard let list = container["Ports"] as? [[String: Any]] else { continue }
+            for entry in list {
+                let proto = jsonString(entry["Type"]) ?? "tcp"
+                let publicPort = jsonInt(entry["PublicPort"])
+                let requestedHost = requestedHost(
+                    dockerHost: jsonString(entry["IP"]),
+                    containerPort: jsonInt(entry["PrivatePort"]),
+                    publicPort: publicPort,
+                    dockerType: proto,
+                    loopbackIntents: loopbackIntents
+                )
+                guard let publicPort,
+                      let binding = PublishedPortBinding(
+                        dockerType: proto,
+                        publicPort: publicPort,
+                        hostIP: requestedHost
+                      ) else {
+                    continue
+                }
+                ports.insert(binding)
+            }
+        }
+        return ports
+    }
 
     /// Parse the trusted label injected by Dory's create-request dataplane. Values outside the
     /// closed vocabulary are ignored so malformed daemon state can never widen exposure.
@@ -248,5 +286,20 @@ public enum PublishedPortForwardPlan {
         (byte >= 48 && byte <= 57)
             || (byte >= 65 && byte <= 90)
             || (byte >= 97 && byte <= 122)
+    }
+
+    private static func jsonInt(_ value: Any?) -> Int? {
+        switch value {
+        case let int as Int:
+            return int
+        case let number as NSNumber:
+            return number.intValue
+        default:
+            return nil
+        }
+    }
+
+    private static func jsonString(_ value: Any?) -> String? {
+        value as? String
     }
 }

--- a/dory-core-swift/Sources/DoryVMMKit/DoryVMMPortForwarder.swift
+++ b/dory-core-swift/Sources/DoryVMMKit/DoryVMMPortForwarder.swift
@@ -1,4 +1,5 @@
 import DoryCore
+import DorydKit
 import Foundation
 
 /// Keeps Docker's published-port inventory synchronized with the gvproxy owned by the macOS 14
@@ -21,6 +22,7 @@ final class DoryVMMPortForwarder: @unchecked Sendable {
     private let lock = NSLock()
     private var started = false
     private var lastLANFailureLog = Date.distantPast
+    private var lastInventoryFailureLog = Date.distantPast
     private var recoveringLANSession = false
 
     init(
@@ -84,7 +86,10 @@ final class DoryVMMPortForwarder: @unchecked Sendable {
     }
 
     private func synchronize() {
-        guard let ports = publishedPorts() else { return }
+        guard let ports = publishedPorts() else {
+            logInventoryUnavailable()
+            return
+        }
         if let client = sourcePreservingLANClient, let sessionID = sourcePreservingLANSessionID {
             do {
                 _ = try client.apply(SourcePreservingLANRequest(
@@ -147,6 +152,13 @@ final class DoryVMMPortForwarder: @unchecked Sendable {
         }
     }
 
+    private func logInventoryUnavailable() {
+        let now = Date()
+        guard now.timeIntervalSince(lastInventoryFailureLog) >= 30 else { return }
+        lastInventoryFailureLog = now
+        log("Docker published-port inventory is unavailable")
+    }
+
     private func logLANFailure(_ message: String) {
         let now = Date()
         guard now.timeIntervalSince(lastLANFailureLog) >= 30 else { return }
@@ -155,38 +167,35 @@ final class DoryVMMPortForwarder: @unchecked Sendable {
     }
 
     private func publishedPorts() -> Set<PublishedPortBinding>? {
-        guard let data = curlData(
-            unixSocket: dockerSocketPath,
-            url: "http://docker/v1.41/containers/json"
-        ), let containers = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+        switch DockerEngineProbe.containerSummaries(socketPath: dockerSocketPath, timeout: 3) {
+        case .unavailable:
             return nil
-        }
-        var result = Set<PublishedPortBinding>()
-        for container in containers {
-            let labels = container["Labels"] as? [String: String]
-            let intents = PublishedPortForwardPlan.loopbackIntents(
-                fromLabel: labels?[PublishedPortForwardPlan.loopbackPortIntentLabel]
-            )
-            guard let ports = container["Ports"] as? [[String: Any]] else { continue }
-            for port in ports {
-                let dockerType = port["Type"] as? String ?? "tcp"
-                let requestedHost = PublishedPortForwardPlan.requestedHost(
-                    dockerHost: port["IP"] as? String,
-                    containerPort: port["PrivatePort"] as? Int,
-                    publicPort: port["PublicPort"] as? Int,
-                    dockerType: dockerType,
-                    loopbackIntents: intents
+        case let .ok(containers):
+            var result = Set<PublishedPortBinding>()
+            for container in containers where container.isRunning {
+                let intents = PublishedPortForwardPlan.loopbackIntents(
+                    fromLabel: container.labels[PublishedPortForwardPlan.loopbackPortIntentLabel]
                 )
-                guard let publicPort = port["PublicPort"] as? Int,
-                      let binding = PublishedPortBinding(
+                for port in container.ports {
+                    let dockerType = port.type ?? "tcp"
+                    let requestedHost = PublishedPortForwardPlan.requestedHost(
+                        dockerHost: port.ip,
+                        containerPort: port.privatePort,
+                        publicPort: port.publicPort,
                         dockerType: dockerType,
-                        publicPort: publicPort,
-                        hostIP: requestedHost
-                      ) else { continue }
-                result.insert(binding)
+                        loopbackIntents: intents
+                    )
+                    guard let publicPort = port.publicPort,
+                          let binding = PublishedPortBinding(
+                            dockerType: dockerType,
+                            publicPort: publicPort,
+                            hostIP: requestedHost
+                          ) else { continue }
+                    result.insert(binding)
+                }
             }
+            return result
         }
-        return result
     }
 
     private func expose(_ forward: PublishedPortForward) -> Bool {
@@ -208,23 +217,6 @@ final class DoryVMMPortForwarder: @unchecked Sendable {
                 "protocol": forward.protocol.rawValue,
             ]
         )
-    }
-
-    private func curlData(unixSocket: String, url: String) -> Data? {
-        let process = Process()
-        let pipe = Pipe()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/curl")
-        process.arguments = [
-            "--fail", "--silent", "--max-time", "3",
-            "--unix-socket", unixSocket,
-            url,
-        ]
-        process.standardOutput = pipe
-        process.standardError = FileHandle.nullDevice
-        guard (try? process.run()) != nil else { return nil }
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        process.waitUntilExit()
-        return process.terminationStatus == 0 ? data : nil
     }
 
     private func post(path: String, body: [String: String]) -> Bool {

--- a/dory-core-swift/Sources/DorydKit/PublishedPortRepairClient.swift
+++ b/dory-core-swift/Sources/DorydKit/PublishedPortRepairClient.swift
@@ -95,10 +95,12 @@ public final class PublishedPortRepairClient: @unchecked Sendable {
                 }
                 guard helperIsCurrent() else { throw RepairError.helperChanged }
                 guard receipt.succeeded else {
-                    let mismatch = "missing \(receipt.missingForwardCount), unexpected \(receipt.unexpectedForwardCount)"
                     throw RepairError.reconciliationFailed(
-                        receipt.error.map { "gvproxy reconciliation failed: \($0) (\(mismatch))" }
-                            ?? "gvproxy reconciliation failed validation (\(mismatch))"
+                        Self.reconciliationFailureDescription(
+                            error: receipt.error,
+                            missingForwardCount: receipt.missingForwardCount,
+                            unexpectedForwardCount: receipt.unexpectedForwardCount
+                        )
                     )
                 }
                 return receipt
@@ -106,6 +108,19 @@ public final class PublishedPortRepairClient: @unchecked Sendable {
             Thread.sleep(forTimeInterval: pollInterval)
         }
         throw RepairError.timeout(timeout)
+    }
+
+    static func reconciliationFailureDescription(
+        error: String?,
+        missingForwardCount: Int,
+        unexpectedForwardCount: Int
+    ) -> String {
+        if let error, error.contains("published-port inventory is unavailable") {
+            return error
+        }
+        let mismatch = "missing \(missingForwardCount), unexpected \(unexpectedForwardCount)"
+        return error.map { "gvproxy reconciliation failed: \($0) (\(mismatch))" }
+            ?? "gvproxy reconciliation failed validation (\(mismatch))"
     }
 
     private func readReceipt(at url: URL) -> PublishedPortReconcileReceipt? {

--- a/dory-core-swift/Tests/DorydKitTests/PublishedPortRepairClientTests.swift
+++ b/dory-core-swift/Tests/DorydKitTests/PublishedPortRepairClientTests.swift
@@ -83,6 +83,43 @@ final class PublishedPortRepairClientTests: XCTestCase {
         }
     }
 
+    func testInventoryUnavailableReceiptDoesNotLookLikeRegistryMismatch() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let receiptURL = directory.appendingPathComponent(PublishedPortReconcileProtocol.receiptFilename)
+        let client = PublishedPortRepairClient(timeout: 0.25, pollInterval: 0.002) { pid in
+            do {
+                let request = try Self.readRequest(in: directory)
+                try Self.writeReceipt(
+                    for: request,
+                    enginePID: pid,
+                    publishedPortCount: 0,
+                    desiredForwardCount: 0,
+                    observedForwardCount: 0,
+                    addedForwardCount: 0,
+                    removedForwardCount: 0,
+                    missing: 0,
+                    unexpected: 0,
+                    error: "Docker published-port inventory is unavailable",
+                    to: receiptURL
+                )
+                return nil
+            } catch {
+                return "\(error)"
+            }
+        }
+
+        XCTAssertThrowsError(try client.reconcile(
+            stateDirectory: directory.path,
+            enginePID: 73,
+            helperIsCurrent: { true }
+        )) { error in
+            let message = "\(error)"
+            XCTAssertEqual(message, "Docker published-port inventory is unavailable")
+            XCTAssertFalse(message.contains("missing 0, unexpected 0"), message)
+        }
+    }
+
     func testRegistryMismatchReceiptCannotReportSuccess() throws {
         let directory = try temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
@@ -188,6 +225,11 @@ final class PublishedPortRepairClientTests: XCTestCase {
     private static func writeReceipt(
         for request: PublishedPortReconcileRequest,
         enginePID: Int32,
+        publishedPortCount: Int = 1,
+        desiredForwardCount: Int = 2,
+        observedForwardCount: Int? = nil,
+        addedForwardCount: Int = 1,
+        removedForwardCount: Int = 1,
         missing: Int = 0,
         unexpected: Int = 0,
         error: String? = nil,
@@ -199,11 +241,11 @@ final class PublishedPortRepairClientTests: XCTestCase {
             enginePID: enginePID,
             startedAt: startedAt,
             finishedAt: startedAt.addingTimeInterval(0.001),
-            publishedPortCount: 1,
-            desiredForwardCount: 2,
-            observedForwardCount: 2 - missing + unexpected,
-            addedForwardCount: 1,
-            removedForwardCount: 1,
+            publishedPortCount: publishedPortCount,
+            desiredForwardCount: desiredForwardCount,
+            observedForwardCount: observedForwardCount ?? (2 - missing + unexpected),
+            addedForwardCount: addedForwardCount,
+            removedForwardCount: removedForwardCount,
             missingForwardCount: missing,
             unexpectedForwardCount: unexpected,
             error: error


### PR DESCRIPTION
## Summary
- Replaces the helper's `/usr/bin/curl` `GET /v1.41/containers/json` poll with the existing in-process unix HTTP client (`GET /containers/json`, 2MB cap) so published-port reconciliation no longer depends on a swallowed 2s curl.
- Fail-closed stays the same when inventory cannot be read, but `dory-hv` now rate-limits a log line and `dory repair ports --apply` keeps `Docker published-port inventory is unavailable` instead of appending `(missing 0, unexpected 0)`.
- This is aimed at [#80](https://github.com/Augani/dory/issues/80). I could **not** reproduce empty gvproxy TCP forwards on a fresh 0.4.5 install, so this is **not** a live-verified fix of that report. I **did** confirm `GET /containers/json` on `~/.dory/hv/engine.sock` returns the published-port list, so a doryd inventory push (Path C) was not added.

## Test plan
- [x] `swift test --package-path dory-core-swift --filter PublishedPortRepairClientTests`
- [x] `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH=1 swift test --no-parallel --package-path Packages/ContainerizationEngine --filter 'GVProxyForwardRegistryTests|PublishedPortForwardPlanTests|UnixSocketHTTPClientTests'`
- [x] Fresh 0.4.5 cask: `dory run -d --rm -p 38099:80 nginx:alpine` bound and `curl http://127.0.0.1:38099/` returned 200 (stock helper, not this branch)
- [ ] Reporter retry on a build that includes this `dory-hv` / `dory-vmm` helper
- [ ] Optional: swap this branch's helper into a running engine and watch one reconcile cycle create the gvproxy TCP forward from `engine.sock`